### PR TITLE
require at least one argument between template or streams

### DIFF
--- a/nds/README.md
+++ b/nds/README.md
@@ -169,7 +169,7 @@ we applied the following changes to original templates released in TPC-DS v3.2.0
 ### Generate Specific Query or Query Streams
 
 ```
-usage: nds_gen_query_stream.py [-h] [--template TEMPLATE] [--streams STREAMS]
+usage: nds_gen_query_stream.py [-h] (--template TEMPLATE | --streams STREAMS)
                                template_dir scale output_dir
 
 positional arguments:

--- a/nds/nds_gen_query_stream.py
+++ b/nds/nds_gen_query_stream.py
@@ -109,7 +109,7 @@ if __name__ == "__main__":
     )
     parser.add_argument("output_dir",
                         help="generate query in directory.")
-    group = parser.add_mutually_exclusive_group()
+    group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--template",
                         help="build queries from this template")
     group.add_argument('--streams',


### PR DESCRIPTION
Signed-off-by: Allen Xu <allxu@nvidia.com>

To close: https://github.com/NVIDIA/spark-rapids-benchmarks/issues/5

This MR will require one argument between `--template` and `--streams`. If neither is specified, user will see the following error:
```bash
usage: nds_gen_query_stream.py [-h] (--template TEMPLATE | --streams STREAMS) template_dir scale output_dir
nds_gen_query_stream.py: error: one of the arguments --template --streams is required
```