### PR TITLE
Add data validation script

### DIFF
--- a/nds/README.md
+++ b/nds/README.md
@@ -201,7 +201,7 @@ python nds_gen_query_stream.py $TPCDS_HOME/query_templates 3000 ./query_streams 
 
 _After_ user generates query streams, Power Run can be executed using one of the them by submitting `nds_power.py` to Spark. 
 
-Arguments supported for `nds_power.py`:
+Arguments supported by `nds_power.py`:
 ```
 usage: nds_power.py [-h] [--output_prefix OUTPUT_PREFIX] [--output_format OUTPUT_FORMAT]
                     input_prefix query_stream_file time_log
@@ -279,34 +279,34 @@ otherwise some query application may be in _WAITING_ status(which can be observe
 Yarn Resource Manager UI) until enough resources are released.
 
 ## Data Validation
-To validate query output between Power Runs w/o GPU, we providing [nds_validate.py](nds_validate.py) to do
+To validate query output between Power Runs w/o GPU, we provide [nds_validate.py](nds_validate.py) to do
 the job.
 
-Arguments supported for `nds_validate.py`:
+Arguments supported by `nds_validate.py`:
 ```
 usage: nds_validate.py [-h] [--max_errors MAX_ERRORS] [--epsilon EPSILON] [--ignore_ordering] [--use_iterator]
                        input1 input2 input_format query_stream_file
 
 positional arguments:
-  input1                path of the first input data
-  input2                path of the second input data
+  input1                path of the first input data.
+  input2                path of the second input data.
   query_stream_file     query stream file that contains NDS queries in specific order.
 
 optional arguments:
-  -h, --help            show this help message and exit
+  -h, --help            show this help message and exit.
   --input_format INPUT_FORMAT
-                        data source type. e.g. parquet, orc. Default is: parquet
+                        data source type. e.g. parquet, orc. Default is: parquet.
   --max_errors MAX_ERRORS
                         Maximum number of differences to report.
   --epsilon EPSILON     Allow for differences in precision when comparing floating point values.
                         Given 2 float numbers: 0.000001 and 0.000000, the diff of them is 0.000001 which is less than the epsilon 0.00001, so we regard this as acceptable and will not report a mismatch.
   --ignore_ordering     Sort the data collected from the DataFrames before comparing them.
-  --use_iterator        When set, use `toLocalIterator` to load one partition at a time into driver memory, reducing
+  --use_iterator        When set, use `toLocalIterator` to load one partition at a time into driver memory, reducing.
                         memory usage at the cost of performance because processing will be single-threaded.
   --floats              whether the input data contains float data or decimal data. There're some known mismatch issues due to float point, we will do some special checks when the input data is float for some queries.
 ```
 
-Example command to compare two query output data:
+Example command to compare output data of two queries:
 ```
 python nds_validate.py \
 query_output_cpu \

--- a/nds/README.md
+++ b/nds/README.md
@@ -278,4 +278,39 @@ in your environment to make sure all Spark job can get necessary resources to ru
 otherwise some query application may be in _WAITING_ status(which can be observed from Spark UI or 
 Yarn Resource Manager UI) until enough resources are released.
 
+## Data Validation
+To validate query output between Power Runs w/o GPU, we providing [nds_validate.py](nds_validate.py) to do
+the job.
+
+Arguments supported for `nds_validate.py`:
+```
+usage: nds_validate.py [-h] [--max_errors MAX_ERRORS] [--epsilon EPSILON] [--ignore_ordering] [--use_iterator]
+                       input1 input2 input_format query_stream_file
+
+positional arguments:
+  input1                path of the first input data
+  input2                path of the second input data
+  input_format          data source type. e.g. parquet, orc
+  query_stream_file     query stream file that contains NDS queries in specific order.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --max_errors MAX_ERRORS
+                        Maximum number of differences to report.
+  --epsilon EPSILON     Allow for differences in precision when comparing floating point values.
+  --ignore_ordering     Sort the data collected from the DataFrames before comparing them.
+  --use_iterator        When set, use `toLocalIterator` to load one partition at atime into driver memory, reducing
+                        memory usage at the cost of performancebecause processing will be single-threaded.
+```
+
+Example command to compare two query output data:
+```
+python validate.py \
+query_output_cpu \
+query_output_gpu \
+parquet \
+./nds_query_streams/query_1.sql \
+--ignore_ordering
+```
+
 ### NDS2.0 is using source code from TPC-DS Tool V3.2.0

--- a/nds/README.md
+++ b/nds/README.md
@@ -311,7 +311,6 @@ Example command to compare two query output data:
 python nds_validate.py \
 query_output_cpu \
 query_output_gpu \
---input_format parquet \
 ./nds_query_streams/query_1.sql \
 --ignore_ordering
 ```

--- a/nds/README.md
+++ b/nds/README.md
@@ -290,26 +290,28 @@ usage: nds_validate.py [-h] [--max_errors MAX_ERRORS] [--epsilon EPSILON] [--ign
 positional arguments:
   input1                path of the first input data
   input2                path of the second input data
-  input_format          data source type. e.g. parquet, orc
   query_stream_file     query stream file that contains NDS queries in specific order.
 
 optional arguments:
   -h, --help            show this help message and exit
+  --input_format INPUT_FORMAT
+                        data source type. e.g. parquet, orc. Default is: parquet
   --max_errors MAX_ERRORS
                         Maximum number of differences to report.
   --epsilon EPSILON     Allow for differences in precision when comparing floating point values.
+                        Given 2 float numbers: 0.000001 and 0.000000, the diff of them is 0.000001 which is less than the epsilon 0.00001, so we regard this as acceptable and will not report a mismatch.
   --ignore_ordering     Sort the data collected from the DataFrames before comparing them.
-  --use_iterator        When set, use `toLocalIterator` to load one partition at atime into driver memory, reducing
-                        memory usage at the cost of performancebecause processing will be single-threaded.
-  --floats              whether the input data contains float data or decimal data.
+  --use_iterator        When set, use `toLocalIterator` to load one partition at a time into driver memory, reducing
+                        memory usage at the cost of performance because processing will be single-threaded.
+  --floats              whether the input data contains float data or decimal data. There're some known mismatch issues due to float point, we will do some special checks when the input data is float for some queries.
 ```
 
 Example command to compare two query output data:
 ```
-python validate.py \
+python nds_validate.py \
 query_output_cpu \
 query_output_gpu \
-parquet \
+--input_format parquet \
 ./nds_query_streams/query_1.sql \
 --ignore_ordering
 ```

--- a/nds/README.md
+++ b/nds/README.md
@@ -284,8 +284,8 @@ the job.
 
 Arguments supported by `nds_validate.py`:
 ```
-usage: nds_validate.py [-h] [--max_errors MAX_ERRORS] [--epsilon EPSILON] [--ignore_ordering] [--use_iterator]
-                       input1 input2 input_format query_stream_file
+usage: nds_validate.py [-h] [--input_format INPUT_FORMAT] [--max_errors MAX_ERRORS] [--epsilon EPSILON]
+                       [--ignore_ordering] [--use_iterator] [--floats] input1 input2 query_stream_file
 
 positional arguments:
   input1                path of the first input data.

--- a/nds/README.md
+++ b/nds/README.md
@@ -301,6 +301,7 @@ optional arguments:
   --ignore_ordering     Sort the data collected from the DataFrames before comparing them.
   --use_iterator        When set, use `toLocalIterator` to load one partition at atime into driver memory, reducing
                         memory usage at the cost of performancebecause processing will be single-threaded.
+  --floats              whether the input data contains float data or decimal data.
 ```
 
 Example command to compare two query output data:

--- a/nds/README.md
+++ b/nds/README.md
@@ -279,8 +279,8 @@ otherwise some query application may be in _WAITING_ status(which can be observe
 Yarn Resource Manager UI) until enough resources are released.
 
 ## Data Validation
-To validate query output between Power Runs w/o GPU, we provide [nds_validate.py](nds_validate.py) to do
-the job.
+To validate query output between Power Runs with and without GPU, we provide [nds_validate.py](nds_validate.py)
+to do the job.
 
 Arguments supported by `nds_validate.py`:
 ```

--- a/nds/nds_validate.py
+++ b/nds/nds_validate.py
@@ -156,13 +156,17 @@ def iterate_queries(spark_session: SparkSession,
                     queries: list,
                     use_iterator=False,
                     max_errors=10,
-                    epsilon=0.00001):
+                    epsilon=0.00001,
+                    is_float=False):
     # Iterate each query folder for a Power Run output
     # Providing a list instead of hard-coding all NDS queires is to satisfy the arbitary queries run.
     unmatch_queries = []
     for query in queries:
         if query == 'query65':
             # query65 is skipped due to: https://github.com/NVIDIA/spark-rapids-benchmarks/pull/7#issuecomment-1147077894
+            continue
+        if query == 'query67' and is_float == True:
+            # query67 is skipped due to: https://github.com/NVIDIA/spark-rapids-benchmarks/pull/7#issuecomment-1156214630
             continue
         sub_input1 = input1 + '/' + query
         sub_input2 = input2 + '/' + query
@@ -209,6 +213,9 @@ if __name__ == "__main__":
                         help='When set, use `toLocalIterator` to load one partition at a' +
                         'time into driver memory, reducing memory usage at the cost of performance' +
                         'because processing will be single-threaded.')
+    parser.add_argument('--floats',
+                        action='store_true',
+                        help='whether the input data contains float data or decimal data.')
     args = parser.parse_args()
     query_dict = gen_sql_from_stream(args.query_stream_file)
     session_builder = SparkSession.builder.appName("Validate Query Output").getOrCreate()
@@ -220,4 +227,5 @@ if __name__ == "__main__":
                     query_dict.keys(),
                     use_iterator=args.use_iterator,
                     max_errors=args.max_errors,
-                    epsilon=args.epsilon)
+                    epsilon=args.epsilon,
+                    is_float=args.floats)

--- a/nds/nds_validate.py
+++ b/nds/nds_validate.py
@@ -1,0 +1,185 @@
+import argparse
+import math
+import time
+from typing import Iterable
+from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql.types import *
+from pyspark.sql.functions import col
+
+from nds_power import gen_sql_from_stream
+
+def compare_results(spark_session: SparkSession,
+                    input1: str,
+                    input2: str,
+                    input_format: str,
+                    ignore_ordering: bool,
+                    use_iterator=False,
+                    max_errors=10,
+                    epsilon=0.00001):
+    """_summary_
+
+    Args:
+        spark_session (SparkSession): Spark Session to hold the comparison
+        input1 (str): path for the first input data
+        input2 (str): path for the second input data
+        input_format (str): data source format, e.g. parquet, orc
+        ignore_ordering (bool): whether ignoring the order of input data.
+            If true, we will order by ourselves.
+        use_iterator (bool, optional): When set to true, use `toLocalIterator` to load one partition
+            at a time into driver memory, reducing memory usage at the cost of performance because
+            processing will be single-threaded. Defaults to False.
+        max_errors (int, optional): Maximum number of differences to report. Defaults to 10.
+        epsilon (float, optional): Allow for differences in precision when comparing floating point
+            values. Defaults to 0.00001.
+
+    Returns:
+        Iterable[Row]: _description_
+    """
+    df1 = spark_session.read.format(input_format).load(input1)
+    df2 = spark_session.read.format(input_format).load(input2)
+    count1 = df1.count()
+    count2 = df2.count()
+
+    if(count1 == count2):
+        #TODO: need partitioned collect for NDS? there's no partitioned output currently
+        result1 = collect_results(df1, ignore_ordering, use_iterator)
+        result2 = collect_results(df2, ignore_ordering, use_iterator)
+
+        errors = 0
+        i = 0
+        while i < count1 and errors < max_errors:
+            lhs = next(result1)
+            rhs = next(result2)
+            if not rowEqual(list(lhs), list(rhs), epsilon):
+                print(f"Row {i}: \n{list(lhs)}\n{list(rhs)}\n")
+                errors += 1
+            i += 1
+        print(f"Processed {i} rows")
+        
+        if errors == max_errors:
+            print(f"Aborting comparison after reaching maximum of {max_errors} errors")
+        elif errors == 0:
+            print("Results match")
+        else:
+            print(f"There were {errors} errors")
+    else:
+        print(f"DataFrame row counts do not match: {count1} != {count2}")
+
+def collect_results(df: DataFrame,
+                   ignore_ordering: bool,
+                   use_iterator: bool):
+    # apply sorting if specified
+    non_float_cols = [col(field.name) for \
+        field in df.schema.fields \
+            if (field.dataType.typeName() != FloatType.typeName()) \
+                and \
+                (field.dataType.typeName() != DoubleType.typeName())]
+    float_cols = [col(field.name) for \
+        field in df.schema.fields \
+            if (field.dataType.typeName() == FloatType.typeName()) \
+                or \
+                (field.dataType.typeName() == DoubleType.typeName())]
+    if ignore_ordering:
+        df = df.sort(non_float_cols + float_cols)
+
+    # TODO: do we still need this for NDS? Query outputs are usually 1 - 100 rows,
+    #       there should'nt be memory pressure.
+    if use_iterator:
+        it = df.toLocalIterator()
+    else:
+        print("Collecting rows from DataFrame")
+        t1 = time.time()
+        rows = df.collect()
+        t2 = time.time()
+        print(f"Collected {len(rows)} rows in {t2-t1} seconds")
+        it = iter(rows)
+    return it
+
+def rowEqual(row1, row2, epsilon):
+    # only simple types in a row for NDS results
+    return all([compare(lhs, rhs, epsilon) for lhs, rhs in zip(row1, row2)])
+
+def compare(expected, actual, epsilon=0.00001):
+    #TODO 1: we can optimize this with case-match after Python 3.10
+    #TODO 2: we can support complex data types like nested type if needed in the future.
+    #        now NDS only contains simple data types.
+    if isinstance(expected, float) and isinstance(actual, float):
+        # Double is converted to float in pyspark...
+        if math.isnan(expected) and math.isnan(actual):
+            return True
+        else:
+            return math.isclose(expected, actual, rel_tol=epsilon)
+    elif isinstance(expected, str) and isinstance(actual, str):
+        return expected == actual
+    elif expected == None and actual == None:
+        return True
+    elif expected != None and actual == None:
+        return False
+    elif expected == None and actual != None:
+        return False
+    else:
+        return expected == actual
+
+def iterate_queries(spark_session: SparkSession,
+                    input1: str,
+                    input2: str,
+                    input_format: str,
+                    ignore_ordering: bool,
+                    queries: list,
+                    use_iterator=False,
+                    max_errors=10,
+                    epsilon=0.00001):
+    # Iterate each query folder for a Power Run output
+    # Providing a list instead of hard-coding all NDS queires is to satify the arbitary queries run.
+    for query in queries:
+        sub_input1 = input1 + '/' + query
+        sub_input2 = input2 + '/' + query
+        print(f"=== Comparing Query: {query} ===")
+        compare_results(spark_session,
+                        sub_input1,
+                        sub_input2,
+                        input_format,
+                        ignore_ordering,
+                        use_iterator=use_iterator,
+                        max_errors=max_errors,
+                        epsilon=epsilon)
+
+
+if __name__ == "__main__":
+    parser = parser = argparse.ArgumentParser()
+    parser.add_argument('input1',
+                        help='path of the first input data')
+    parser.add_argument('input2',
+                        help='path of the second input data')
+    parser.add_argument('input_format',
+                        help='data source type. e.g. parquet, orc')
+    parser.add_argument('query_stream_file',
+                        help='query stream file that contains NDS queries in specific order.')
+    parser.add_argument('--max_errors',
+                        help='Maximum number of differences to report.',
+                        type=int,
+                        default=10)
+    parser.add_argument('--epsilon',
+                        type=float,
+                        default=0.00001,
+                        help='Allow for differences in precision when comparing floating point values.')
+    parser.add_argument('--ignore_ordering',
+                        action='store_true',
+                        help='Sort the data collected from the DataFrames before comparing them.')
+    parser.add_argument('--use_iterator',
+                        action='store_true',
+                        help='When set, use `toLocalIterator` to load one partition at a' +
+                        'time into driver memory, reducing memory usage at the cost of performance' +
+                        'because processing will be single-threaded.')
+    args = parser.parse_args()
+    query_dict = gen_sql_from_stream(args.query_stream_file)
+    session_builder = SparkSession.builder.appName("Validate Query Output").getOrCreate()
+    iterate_queries(session_builder,
+                    args.input1,
+                    args.input2,
+                    args.input_format,
+                    args.ignore_ordering,
+                    query_dict.keys(),
+                    use_iterator=args.use_iterator,
+                    max_errors=args.max_errors,
+                    epsilon=args.epsilon)

--- a/nds/nds_validate.py
+++ b/nds/nds_validate.py
@@ -33,6 +33,7 @@ import argparse
 import math
 import time
 from decimal import *
+
 from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql.types import *
 from pyspark.sql.functions import col
@@ -202,16 +203,16 @@ def iterate_queries(spark_session: SparkSession,
         sub_input1 = input1 + '/' + query
         sub_input2 = input2 + '/' + query
         print(f"=== Comparing Query: {query} ===")
-        compare_result = compare_results(spark_session,
-                        sub_input1,
-                        sub_input2,
-                        input_format,
-                        ignore_ordering,
-                        query == 'query78',
-                        use_iterator=use_iterator,
-                        max_errors=max_errors,
-                        epsilon=epsilon)
-        if compare_result == False:
+        result_equal = compare_results(spark_session,
+                                         sub_input1,
+                                         sub_input2,
+                                         input_format,
+                                         ignore_ordering,
+                                         query == 'query78',
+                                         use_iterator=use_iterator,
+                                         max_errors=max_errors,
+                                         epsilon=epsilon)
+        if result_equal == False:
             unmatch_queries.append(query)
     if len(unmatch_queries) != 0:
         print(f"=== Unmatch Queries: {unmatch_queries} ===")

--- a/nds/nds_validate.py
+++ b/nds/nds_validate.py
@@ -184,7 +184,6 @@ def iterate_queries(spark_session: SparkSession,
             unmatch_queries.append(query)
     if len(unmatch_queries) != 0:
         print(f"=== Unmatch Queries: {unmatch_queries} ===")
-        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/nds/nds_validate.py
+++ b/nds/nds_validate.py
@@ -137,6 +137,7 @@ def collect_results(df: DataFrame,
 def rowEqual(row1, row2, epsilon, is_q78):
     # only simple types in a row for NDS results
     if is_q78:
+        # TODO: make the special compare for q78 more common and make it apply to other queries that contain round function
         # TODO: remove this special case after we resolve https://github.com/NVIDIA/spark-rapids/issues/1573
         # see example error case: https://github.com/NVIDIA/spark-rapids-benchmarks/pull/7#issue-1247422850
         # Pop the 4th column value in q78, compare it alone.

--- a/nds/nds_validate.py
+++ b/nds/nds_validate.py
@@ -31,7 +31,6 @@
 
 import argparse
 import math
-import sys
 import time
 from decimal import *
 from pyspark.sql import DataFrame, SparkSession
@@ -197,7 +196,7 @@ def iterate_queries(spark_session: SparkSession,
         if query == 'query65':
             # query65 is skipped due to: https://github.com/NVIDIA/spark-rapids-benchmarks/pull/7#issuecomment-1147077894
             continue
-        if query == 'query67' and is_float == True:
+        if query == 'query67' and is_float:
             # query67 is skipped due to: https://github.com/NVIDIA/spark-rapids-benchmarks/pull/7#issuecomment-1156214630
             continue
         sub_input1 = input1 + '/' + query
@@ -221,14 +220,14 @@ def iterate_queries(spark_session: SparkSession,
 if __name__ == "__main__":
     parser = parser = argparse.ArgumentParser()
     parser.add_argument('input1',
-                        help='path of the first input data')
+                        help='path of the first input data.')
     parser.add_argument('input2',
-                        help='path of the second input data')
+                        help='path of the second input data.')
     parser.add_argument('query_stream_file',
                         help='query stream file that contains NDS queries in specific order.')
     parser.add_argument('--input_format',
                         default='parquet',
-                        help='data source type. e.g. parquet, orc. Default is: parquet')
+                        help='data source type. e.g. parquet, orc. Default is: parquet.')
     parser.add_argument('--max_errors',
                         help='Maximum number of differences to report.',
                         type=int,

--- a/nds/nds_validate.py
+++ b/nds/nds_validate.py
@@ -1,3 +1,34 @@
+# -*- coding: utf-8 -*-
+#
+# SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# -----
+#
+# Certain portions of the contents of this file are derived from TPC-DS version 3.2.0
+# (retrieved from www.tpc.org/tpc_documents_current_versions/current_specifications5.asp).
+# Such portions are subject to copyrights held by Transaction Processing Performance Council (“TPC”)
+# and licensed under the TPC EULA (a copy of which accompanies this file as “TPC EULA” and is also
+# available at http://www.tpc.org/tpc_documents_current_versions/current_specifications5.asp) (the “TPC EULA”).
+#
+# You may not use this file except in compliance with the TPC EULA.
+# DISCLAIMER: Portions of this file is derived from the TPC-DS Benchmark and as such any results
+# obtained using this file are not comparable to published TPC-DS Benchmark results, as the results
+# obtained from using this file do not comply with the TPC-DS Benchmark.
+#
+
 import argparse
 import math
 import sys
@@ -192,10 +223,11 @@ if __name__ == "__main__":
                         help='path of the first input data')
     parser.add_argument('input2',
                         help='path of the second input data')
-    parser.add_argument('input_format',
-                        help='data source type. e.g. parquet, orc')
     parser.add_argument('query_stream_file',
                         help='query stream file that contains NDS queries in specific order.')
+    parser.add_argument('--input_format',
+                        default='parquet',
+                        help='data source type. e.g. parquet, orc. Default is: parquet')
     parser.add_argument('--max_errors',
                         help='Maximum number of differences to report.',
                         type=int,
@@ -203,18 +235,23 @@ if __name__ == "__main__":
     parser.add_argument('--epsilon',
                         type=float,
                         default=0.00001,
-                        help='Allow for differences in precision when comparing floating point values.')
+                        help='Allow for differences in precision when comparing floating point values.' +
+                        ' Given 2 float numbers: 0.000001 and 0.000000, the diff of them is 0.000001' +
+                        ' which is less than 0.00001, so we regard this as acceptable and will not' +
+                        ' report a mismatch.')
     parser.add_argument('--ignore_ordering',
                         action='store_true',
                         help='Sort the data collected from the DataFrames before comparing them.')
     parser.add_argument('--use_iterator',
                         action='store_true',
                         help='When set, use `toLocalIterator` to load one partition at a' +
-                        'time into driver memory, reducing memory usage at the cost of performance' +
-                        'because processing will be single-threaded.')
+                        ' time into driver memory, reducing memory usage at the cost of performance' +
+                        ' because processing will be single-threaded.')
     parser.add_argument('--floats',
                         action='store_true',
-                        help='whether the input data contains float data or decimal data.')
+                        help='whether the input data contains float data or decimal data. There\'re' +
+                        ' some known mismatch issues due to float point, we will do some special' +
+                        ' checks when the input data is float for some queries.')
     args = parser.parse_args()
     query_dict = gen_sql_from_stream(args.query_stream_file)
     session_builder = SparkSession.builder.appName("Validate Query Output").getOrCreate()

--- a/nds/nds_validate.py
+++ b/nds/nds_validate.py
@@ -161,6 +161,9 @@ def iterate_queries(spark_session: SparkSession,
     # Providing a list instead of hard-coding all NDS queires is to satisfy the arbitary queries run.
     unmatch_queries = []
     for query in queries:
+        if query == 'query65':
+            # query65 is skipped due to: https://github.com/NVIDIA/spark-rapids-benchmarks/pull/7#issuecomment-1147077894
+            continue
         sub_input1 = input1 + '/' + query
         sub_input2 = input2 + '/' + query
         print(f"=== Comparing Query: {query} ===")

--- a/nds/nds_validate.py
+++ b/nds/nds_validate.py
@@ -2,6 +2,7 @@ import argparse
 import math
 import sys
 import time
+from decimal import *
 from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql.types import *
 from pyspark.sql.functions import col
@@ -142,6 +143,8 @@ def compare(expected, actual, epsilon=0.00001):
         return False
     elif expected == None and actual != None:
         return False
+    elif isinstance(expected, Decimal) and isinstance(actual, Decimal):
+        return math.isclose(expected, actual, rel_tol=epsilon)
     else:
         return expected == actual
 

--- a/nds/nds_validate.py
+++ b/nds/nds_validate.py
@@ -17,7 +17,8 @@ def compare_results(spark_session: SparkSession,
                     use_iterator=False,
                     max_errors=10,
                     epsilon=0.00001) -> bool :
-    """_summary_
+    """Giving 2 paths of input query output data, compare them row by row, value by value to see if
+    the results match or not.
 
     Args:
         spark_session (SparkSession): Spark Session to hold the comparison


### PR DESCRIPTION
Signed-off-by: Allen Xu <allxu@nvidia.com>

To close: https://github.com/NVIDIA/spark-rapids-benchmarks/issues/3.

This PR adds in a new script to do data validation for NDS queries.

In NDS benchmark we are comparing the query execution times between w/o GPU. It's necessary to compare the query outputs between CPU vs. GPU runs to make sure the spark-rapids plugin is working as expected.


The example log when comparing the output of a query:
```
=== Comparing Query: query18 ===
Collecting rows from DataFrame
Collected 100 rows in 0.05885505676269531 seconds
Collecting rows from DataFrame
Collected 100 rows in 0.04702019691467285 seconds
Processed 100 rows
Results match
```

We are now facing an inconsistency result for query 78 which is caused by GpuRound when processing floating point numbers.
```
=== Comparing Query: query78 ===
=== Comparing Query: query78 ===
Collecting rows from DataFrame
Collected 100 rows in 0.06273078918457031 seconds
Collecting rows from DataFrame
Collected 100 rows in 0.052698612213134766 seconds
Row 84:
[2000, 11738, 364891, 1.78, 71, Decimal('8.10'), Decimal('9.39'), 40, Decimal('58.93'), Decimal('16.14')]
[2000, 11738, 364891, 1.77, 71, Decimal('8.10'), Decimal('9.39'), 40, Decimal('58.93'), Decimal('16.14')]

Processed 100 rows
There were 1 errors
```
According to the current [document](https://github.com/NVIDIA/spark-rapids/blob/branch-22.06/docs/compatibility.md#floating-point), it is acceptable, so I  add some extra code to deal with query78 specifically. 