### PR TITLE
Remove dbgen_version table

### DIFF
--- a/nds/nds_transcode.py
+++ b/nds/nds_transcode.py
@@ -63,12 +63,6 @@ def get_schemas(use_decimal):
         dict: {table_name: schema}
     """
     SCHEMAS = {}
-    SCHEMAS["dbgen_version"] = StructType([
-        StructField("dv_version", VarcharType(16)),
-        StructField("dv_create_date", DateType()),
-        StructField("dv_create_time", TimestampType()),
-        StructField("dv_cmdline_args", VarcharType(200))
-    ])
 
     SCHEMAS["customer_address"] = StructType([
         StructField("ca_address_sk", IntegerType(), nullable=False),


### PR DESCRIPTION
Signed-off-by: Allen Xu <allxu@nvidia.com>

To close: https://github.com/NVIDIA/spark-rapids-benchmarks/issues/18.

Remove the unused table in the schema dict to be able to convert data generated from tools other than official TPC-DS one.