### PR TITLE
Fix the table_name

### DIFF
--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -96,7 +96,7 @@ def setup_tables(spark_session, input_prefix, input_format, use_decimal, executi
     for table_name in get_schemas(False).keys():
         start = int(time.time() * 1000)
         table_path = input_prefix + '/' + table_name
-        spark_session.read.format(input_format).schema(get_schemas(use_decimal)['table_name']).load(
+        spark_session.read.format(input_format).schema(get_schemas(use_decimal)[table_name]).load(
             table_path).createOrReplaceTempView(table_name)
         end = int(time.time() * 1000)
         print("====== Creating TempView for table {} ======".format(table_name))


### PR DESCRIPTION
The code used 'table_name' for the variable by mistake in https://github.com/NVIDIA/spark-rapids-benchmarks/pull/22.
To close: https://github.com/NVIDIA/spark-rapids-benchmarks/issues/28.

Signed-off-by: Gary Shen <gashen@nvidia.com>