### PR TITLE
add 60s sleep before shutting down SparkContext

### DIFF
--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -222,9 +222,14 @@ def run_query_stream(input_prefix,
         else:
             summary_prefix = ''
         q_report.write_summary(query_name, prefix=summary_prefix)
+    power_end = time.time()
+    power_elapse = int((power_end - power_start)*1000)
+    # Sleep for 60 seconds to ensure threads for listener event processing are done.
+    # See more details here:https://github.com/NVIDIA/spark-rapids-benchmarks/issues/37
+    # TODO: use better JVM way to add listener.
+    time.sleep(60)
     spark_session.sparkContext.stop()
     total_time_end = time.time()
-    power_elapse = int((total_time_end - power_start)*1000)
     total_elapse = int((total_time_end - total_time_start)*1000)
     print("====== Power Test Time: {} milliseconds ======".format(power_elapse))
     print("====== Total Time: {} milliseconds ======".format(total_elapse))


### PR DESCRIPTION
Signed-off-by: Allen Xu <allxu@nvidia.com>
This is a workaround for https://github.com/NVIDIA/spark-rapids-benchmarks/issues/37.

Also update the time point of "Power Test End" according to the specification:
```
Power Test End Time, which is the timestamp that must be taken after the last character of output data from 
the last query of Stream 0 is received by the driver from the SUT.
```