### PR TITLE
clean generation cmd to avoid duplication

### DIFF
--- a/nds/tpcds-gen/pom.xml
+++ b/nds/tpcds-gen/pom.xml
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
-      <version>2.7.0</version>
+      <version>3.2.1</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/nds/tpcds-gen/src/main/java/org/notmysock/tpcds/GenTable.java
+++ b/nds/tpcds-gen/src/main/java/org/notmysock/tpcds/GenTable.java
@@ -191,8 +191,8 @@ public class GenTable extends Configured implements Tool {
         Path in = new Path("/tmp/"+table+"_"+scale+"-"+epoch);
         FileSystem fs = FileSystem.get(getConf());
         FSDataOutputStream out = fs.create(in);
-        String cmd = "";
         for(int i = rangeStart; i <= rangeEnd; i++) {
+          String cmd = "";
           if(table.equals("all")) {
             cmd += String.format("./dsdgen -dir $DIR -force Y -scale %d -parallel %d -child %d", scale, parallel, i);
           } else {


### PR DESCRIPTION
The problem is that the cmd variable was not cleaned in every iteration of the loop.
The 2nd, 3nd ... iteration included 2, 3 commands.
Signed-off-by: Allen Xu <allxu@nvidia.com>
close: #52 