### PR TITLE
Remove out of date notes and update python minimum version requirement

### DIFF
--- a/nds/README.md
+++ b/nds/README.md
@@ -18,7 +18,7 @@ You may not use NDS except in compliance with the Apache License, Version 2.0 an
 
 ## prerequisites:
 
-1. python > 3.6
+1. python >= 3.6
 2. Necessary libraries 
     ```
     sudo apt install openjdk-8-jdk-headless gcc make flex bison byacc maven

--- a/nds/README.md
+++ b/nds/README.md
@@ -50,9 +50,6 @@ Then two jars will be built at:
 
 ### Generate data
 
-
-Note: please make sure you have `Hadoop binary` locally.
-
 How to generate data to local or HDFS:
 ```
 $ python nds_gen_data.py -h


### PR DESCRIPTION
Signed-off-by: Allen Xu <allxu@nvidia.com>
Remove a phrase that is out of date and may confuse users, update Python minimum version from `>3.6` to `>=3.6`