### PR TITLE
Write to csv the query time without brackets

### DIFF
--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -223,7 +223,11 @@ def run_query_stream(input_prefix,
                                                    output_path,
                                                    output_format)
         print(f"Time taken: {summary['queryTimes']} millis for {query_name}")
-        execution_time_list.append((spark_app_id, query_name, summary['queryTimes']))
+        query_times = summary['queryTimes']
+        num_iterations = len(query_times)
+        if num_iterations != 1:
+            raise Exception(f"Query {query_name} had {num_iterations} iterations but 1 expected.")
+        execution_time_list.append((spark_app_id, query_name, query_times[0]))
         # property_file e.g.: "property/aqe-on.properties" or just "aqe-off.properties"
         if property_file:
             summary_prefix = os.path.join(


### PR DESCRIPTION
Signed-off-by: Alessandro Bellina <abellina@nvidia.com>

This fixes a small issue where query times were being serialized with brackets, e.g.:

```
app-20220727195545-0022,query83,[5877]
```

This makes parsing the resulting CSV a bit cumbersome. This PR changes the output to be:

```
app-20220727195545-0022,query83,5877
```
This PR ensures that there is 1 result per query, and then takes that first result as the only result. If we need to support multiple iterations (hot/cold) in the future, we'll need to change that code.