### PR TITLE
register delete table before querying

### DIFF
--- a/nds/PysparkBenchReport.py
+++ b/nds/PysparkBenchReport.py
@@ -90,6 +90,8 @@ class PysparkBenchReport:
             else:
                 self.summary['queryStatus'].append("Completed")
         except Exception as e:
+            # print the exception to ease debugging
+            print(e)
             end_time = int(time.time() * 1000)
             self.summary['queryStatus'].append("Failed")
             self.summary['exceptions'].append(str(e))

--- a/nds/README.md
+++ b/nds/README.md
@@ -331,6 +331,10 @@ time.csv \
 --data_format orc
 ```
 
+Note: to make the maintenance query compatible in Spark, we made the following changes:
+1. change `CREATE VIEW` to `CREATE TEMP VIEW` in all INSERT queries due to [[SPARK-29630]](https://github.com/apache/spark/pull/26361)
+2. change data type for column `sret_ticket_number` in table `s_store_returns` from `char(20)` to `bigint` due to [known issue](https://github.com/NVIDIA/spark-rapids-benchmarks/pull/9#issuecomment-1138379596)
+
 ## Data Validation
 To validate query output between Power Runs with and without GPU, we provide [nds_validate.py](nds_validate.py)
 to do the job.

--- a/nds/data_maintenance/LF_CR.sql
+++ b/nds/data_maintenance/LF_CR.sql
@@ -29,7 +29,7 @@
 --
 
 DROP VIEW IF EXISTS crv;
-CREATE VIEW crv as
+CREATE TEMP VIEW crv as
 SELECT d_date_sk cr_returned_date_sk
  ,t_time_sk cr_returned_time_sk
  ,i_item_sk cr_item_sk

--- a/nds/data_maintenance/LF_CS.sql
+++ b/nds/data_maintenance/LF_CS.sql
@@ -29,7 +29,7 @@
 --
 
 DROP VIEW IF EXISTS csv;
-CREATE view csv as
+CREATE TEMP view csv as
 SELECT d1.d_date_sk cs_sold_date_sk 
  ,t_time_sk cs_sold_time_sk 
  ,d2.d_date_sk cs_ship_date_sk

--- a/nds/data_maintenance/LF_I.sql
+++ b/nds/data_maintenance/LF_I.sql
@@ -29,7 +29,7 @@
 --
 
 DROP VIEW IF EXISTS iv;
-CREATE view iv AS
+CREATE TEMP view iv AS
 SELECT d_date_sk inv_date_sk,
  i_item_sk inv_item_sk,
  w_warehouse_sk inv_warehouse_sk,

--- a/nds/data_maintenance/LF_SR.sql
+++ b/nds/data_maintenance/LF_SR.sql
@@ -29,7 +29,7 @@
 --
 
 DROP VIEW IF EXISTS srv;
-CREATE view srv as
+CREATE TEMP view srv as
 SELECT d_date_sk sr_returned_date_sk
  ,t_time_sk sr_return_time_sk
  ,i_item_sk sr_item_sk

--- a/nds/data_maintenance/LF_SS.sql
+++ b/nds/data_maintenance/LF_SS.sql
@@ -29,7 +29,7 @@
 --
 
 DROP VIEW IF EXISTS ssv;
-CREATE view ssv as
+CREATE TEMP view ssv as
 SELECT d_date_sk ss_sold_date_sk, 
  t_time_sk ss_sold_time_sk, 
  i_item_sk ss_item_sk, 

--- a/nds/data_maintenance/LF_WR.sql
+++ b/nds/data_maintenance/LF_WR.sql
@@ -29,7 +29,7 @@
 --
 
 DROP VIEW IF EXISTS wrv;
-CREATE VIEW wrv AS
+CREATE TEMP VIEW wrv AS
 SELECT d_date_sk wr_return_date_sk
  ,t_time_sk wr_return_time_sk
  ,i_item_sk wr_item_sk

--- a/nds/data_maintenance/LF_WS.sql
+++ b/nds/data_maintenance/LF_WS.sql
@@ -29,7 +29,7 @@
 --
 
 DROP VIEW IF EXISTS wsv;
-CREATE VIEW wsv AS
+CREATE TEMP VIEW wsv AS
 SELECT d1.d_date_sk ws_sold_date_sk, 
  t_time_sk ws_sold_time_sk, 
  d2.d_date_sk ws_ship_date_sk,

--- a/nds/nds_maintenance.py
+++ b/nds/nds_maintenance.py
@@ -54,7 +54,7 @@ DELETE_FUNCS = [
 INVENTORY_DELETE_FUNC = ['DF_I']
 DM_FUNCS = INSERT_FUNCS + DELETE_FUNCS + INVENTORY_DELETE_FUNC
 
-def get_delete_date(spark_session):
+def get_delete_date(spark_session, refresh_data_path, refresh_data_format):
     """get delete dates for Data Maintenance. Each delete functions requires 3 tuples: (date1, date2)
 
     Args:
@@ -62,6 +62,7 @@ def get_delete_date(spark_session):
     Returns:
         delete_dates_dict ({str: list[(date1, date2)]}): a dict contains date tuples for each delete functions
     """
+    register_temp_views(spark_session, refresh_data_path, refresh_data_format)
     delete_dates = spark_session.sql("select * from delete").collect()
     inventory_delete_dates = spark_session.sql("select * from inventory_delete").collect()
     date_dict = {}

--- a/nds/nds_maintenance.py
+++ b/nds/nds_maintenance.py
@@ -85,7 +85,7 @@ def replace_date(query_list, date_tuple_list):
             q_updated.append(c)
     return q_updated
 
-def get_maintenance_queries(folder, spec_queries):
+def get_maintenance_queries(folder, spec_queries, refresh_data_path, refresh_data_format):
     """get query content from DM query files
 
     Args:
@@ -96,7 +96,7 @@ def get_maintenance_queries(folder, spec_queries):
     """
     # need a spark session to get delete date
     spark = SparkSession.builder.appName("GET DELETE DATES").getOrCreate()
-    delete_date_dict = get_delete_date(spark)
+    delete_date_dict = get_delete_date(spark, refresh_data_path, refresh_data_format)
     # exclude this "get_delte_date" step from main DM process.
     spark.stop()
     global DM_FUNCS
@@ -206,5 +206,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
     query_dict = get_maintenance_queries(args.maintenance_queries_folder,
-                                         args.maintenance_queries)
+                                         args.maintenance_queries,
+                                         args.refresh_data_path,
+                                         args.data_format)
     run_query(query_dict, args.time_log, args.refresh_data_path, args.data_format)

--- a/nds/nds_maintenance.py
+++ b/nds/nds_maintenance.py
@@ -90,7 +90,7 @@ def get_valid_query_names(spec_queries):
         for q in spec_queries:
             if q not in DM_FUNCS:
                 raise Exception(f"invalid Data Maintenance query: {q}. Valid  are: {DM_FUNCS}")
-        DM_FUNCS = [q for q in spec_queries if q in DM_FUNCS]
+        DM_FUNCS = spec_queries
     return DM_FUNCS
 
 def create_spark_session(valid_queries):
@@ -182,7 +182,7 @@ def run_query(spark_session, query_dict, time_log_output_path):
 def register_temp_views(spark_session, refresh_data_path, data_format):
     refresh_tables = get_maintenance_schemas(True).keys()
     for table in refresh_tables:
-        df = spark_session.read.format(data_format).load(
+        spark_session.read.format(data_format).load(
             refresh_data_path + '/' + table).createOrReplaceTempView(table)
 
 if __name__ == "__main__":

--- a/nds/nds_transcode.py
+++ b/nds/nds_transcode.py
@@ -644,7 +644,7 @@ def get_maintenance_schemas(use_decimal):
         StructField("sret_customer_id", CharType(16)),
         StructField("sret_return_date", CharType(10)),
         StructField("sret_return_time", CharType(10)),
-        StructField("sret_ticket_number", CharType(20)),
+        StructField("sret_ticket_number", LongType()),
         StructField("sret_return_qty", IntegerType()),
         StructField("sret_return_amt", decimalType(use_decimal, 7,2)),
         StructField("sret_return_tax", decimalType(use_decimal, 7,2)),
@@ -692,7 +692,7 @@ def get_maintenance_schemas(use_decimal):
          StructField("wret_return_fee", decimalType(use_decimal,7,2)),
          StructField("wret_return_ship_cost", decimalType(use_decimal,7,2)),
          StructField("wret_refunded_cash", decimalType(use_decimal,7,2)),
-         StructField("wret_reversed_CharTypege", decimalType(use_decimal,7,2)),
+         StructField("wret_reversed_charge", decimalType(use_decimal,7,2)),
          StructField("wret_account_credit", decimalType(use_decimal,7,2)),
          StructField("wret_reason_id", CharType(16)),
     ])


### PR DESCRIPTION
Signed-off-by: Allen Xu <allxu@nvidia.com>
close: https://github.com/NVIDIA/spark-rapids-benchmarks/issues/88 .


1. Refactor some functions to avoid duplicated SparkSession instances.
2. This PR also made some modifications to maintenance queries(INSERT queries) and update data schema to make data maintenance work.

Test pass in local test.