### PR TITLE
Avoid creating local metastore_db

### DIFF
--- a/nds/nds_maintenance.py
+++ b/nds/nds_maintenance.py
@@ -111,10 +111,6 @@ def create_spark_session(valid_queries, warehouse_path, warehouse_type):
     spark_session_builder = SparkSession.builder
     if warehouse_type == "iceberg":
         spark_session_builder.config("spark.sql.catalog.spark_catalog.warehouse", warehouse_path)
-    elif warehouse_type == "delta":
-        # TODO: find a way to set the warehouse path in Spark config.
-        # The following config doesn't work for Delta Lake warehouse, but no harm. So keep it.
-        spark_session_builder.config("spark.sql.warehouse.dir", warehouse_path)
     spark_session = spark_session_builder.appName(app_name).getOrCreate()
     return spark_session
 

--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -215,7 +215,7 @@ def run_query_stream(input_prefix,
             session_builder = session_builder.config(k,v)
     if input_format == 'iceberg':
         session_builder.config("spark.sql.catalog.spark_catalog.warehouse", input_prefix)
-    if input_format == 'delta':
+    if input_format == 'delta' and not delta_unmanaged:
         session_builder.config("spark.sql.warehouse.dir", input_prefix)
         session_builder.config("spark.sql.catalogImplementation", "hive")
     spark_session = session_builder.appName(

--- a/nds/nds_transcode.py
+++ b/nds/nds_transcode.py
@@ -137,7 +137,7 @@ def transcode(args):
     session_builder = pyspark.sql.SparkSession.builder
     if args.output_format == "iceberg":
         session_builder.config("spark.sql.catalog.spark_catalog.warehouse", args.output_prefix)
-    if args.output_format == "delta":
+    if args.output_format == "delta" and not args.delta_unmanaged:
         session_builder.config("spark.sql.warehouse.dir", args.output_prefix)
         session_builder.config("spark.sql.catalogImplementation", "hive")
     session = session_builder.appName(f"NDS - transcode - {args.output_format}").getOrCreate()


### PR DESCRIPTION
Signed-off-by: Allen Xu <allxu@nvidia.com>
In local test cases where user want to create and use Delta unmanaged tables without Hive metastore service, current code will create "metastore_db"  during transcoding at first. 
Consider the following use case:
1. user transcode raw data to Delta unmanaged tables to path `/a/b/c/store_sales`. now the "metastore_db" is created and record some metainfo, especially table path `/a/b/c/store_sales`
2. user manually moves folder from `/a/b/c` to `/a/b/d`
3. user runs power test with new input path `/a/b/d`
Then user will see logs like `22/09/30 03:19:50 INFO DeltaLog: No delta log found for the Delta table at file:/a/b/c/store_sales/_delta_log` because the metastore_db still records the old data path. 

The new code will not create metastore_db when user specify `--delta_unmanaged`