### PR TITLE
support Hive external tables

### DIFF
--- a/nds/README.md
+++ b/nds/README.md
@@ -146,7 +146,7 @@ user doesn't need to create the Metastore service,  appending `--delta_unmanaged
 Arguments for `nds_transcode.py`:
 ```
 python nds_transcode.py -h
-usage: nds_transcode.py [-h] [--output_mode {overwrite,append,ignore,error,errorifexists}] [--output_format {parquet,orc,avro,json,iceberg,delta}] [--tables TABLES] [--log_level LOG_LEVEL] [--floats] [--update] [--iceberg_write_format {parquet,orc,avro}] [--compression COMPRESSION] [--delta_unmanaged]
+usage: nds_transcode.py [-h] [--output_mode {overwrite,append,ignore,error,errorifexists}] [--output_format {parquet,orc,avro,json,iceberg,delta}] [--tables TABLES] [--log_level LOG_LEVEL] [--floats] [--update] [--iceberg_write_format {parquet,orc,avro}] [--compression COMPRESSION] [--delta_unmanaged] [--hive]
                         input_prefix output_prefix report_file
 
 positional arguments:
@@ -174,6 +174,7 @@ optional arguments:
                         https://spark.apache.org/docs/latest/sql-data-sources.html for supported codecs for Spark built-in formats. When not specified, the default for the requested output format will be used.
   --delta_unmanaged     Use unmanaged tables for DeltaLake. This is useful for testing DeltaLake without leveraging a
                         Metastore service
+  --hive                create Hive external tables for the converted data.
 ```
 
 Example command to submit via `spark-submit-template` utility:
@@ -268,7 +269,7 @@ _After_ user generates query streams, Power Run can be executed using one of the
 
 Arguments supported by `nds_power.py`:
 ```
-usage: nds_power.py [-h] [--input_format {parquet,orc,avro,csv,json,iceberg,delta}] [--output_prefix OUTPUT_PREFIX] [--output_format OUTPUT_FORMAT] [--property_file PROPERTY_FILE] [--floats] [--json_summary_folder JSON_SUMMARY_FOLDER] [--delta_unmanaged] input_prefix query_stream_file time_log
+usage: nds_power.py [-h] [--input_format {parquet,orc,avro,csv,json,iceberg,delta}] [--output_prefix OUTPUT_PREFIX] [--output_format OUTPUT_FORMAT] [--property_file PROPERTY_FILE] [--floats] [--json_summary_folder JSON_SUMMARY_FOLDER] [--delta_unmanaged] [--hive] input_prefix query_stream_file time_log
 
 positional arguments:
   input_prefix          text to prepend to every input file path (e.g., "hdfs:///ds-generated-data"). If input_format is "iceberg", this argument will be regarded as the value of property "spark.sql.catalog.spark_catalog.warehouse". Only default Spark catalog session name
@@ -291,6 +292,7 @@ optional arguments:
                         Empty folder/path (will create if not exist) to save JSON summary file for each query.
   --delta_unmanaged     Use unmanaged tables for DeltaLake. This is useful for testing DeltaLake without leveraging a
                         Metastore service
+  --hive                use table meta information in Hive metastore directly without registering temp views.
 ```
 
 Example command to submit nds_power.py by spark-submit-template utility:

--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -304,7 +304,7 @@ if __name__ == "__main__":
                         'Certain types are not fully supported by GPU reading, please refer to ' +
                         'https://github.com/NVIDIA/spark-rapids/blob/branch-22.08/docs/compatibility.md ' +
                         'for more details.',
-                        choices=['parquet', 'orc', 'avro', 'csv', 'json', 'iceberg', 'delta', 'hive'],
+                        choices=['parquet', 'orc', 'avro', 'csv', 'json', 'iceberg', 'delta'],
                         default='parquet')
     parser.add_argument('--output_prefix',
                         help='text to prepend to every output file (e.g., "hdfs:///ds-parquet")')

--- a/nds/nds_transcode.py
+++ b/nds/nds_transcode.py
@@ -65,7 +65,8 @@ def store(session,
           iceberg_write_format,
           compression,
           prefix="",
-          delta_unmanaged=False):
+          delta_unmanaged=False,
+          hive_external=False):
     """Create Iceberg tables by CTAS
 
     Args:
@@ -125,13 +126,21 @@ def store(session,
             writer = df.write
             if compression:
                 writer = writer.option('compression', compression)
-            writer.format(output_format).mode(
-                output_mode).partitionBy(TABLE_PARTITIONING[filename]).save(data_path)
+            writer = writer.format(output_format).mode(
+                output_mode).partitionBy(TABLE_PARTITIONING[filename])
+            if not hive_external:
+                writer.save(data_path)
+            else:
+                writer.saveAsTable(filename, path=data_path)
         else:
             writer = df.coalesce(1).write
             if compression:
                 writer = writer.option('compression', compression)
-            writer.format(output_format).mode(output_mode).save(data_path)
+            writer = writer.format(output_format).mode(output_mode)
+            if not hive_external:
+                writer.save(data_path)
+            else:
+                writer.saveAsTable(filename, path=data_path)
 
 def transcode(args):
     session_builder = pyspark.sql.SparkSession.builder
@@ -174,7 +183,8 @@ def transcode(args):
                           args.iceberg_write_format,
                           args.compression,
                           args.output_prefix,
-                          args.delta_unmanaged),
+                          args.delta_unmanaged,
+                          args.hive),
             number=1)
         
     end_time = datetime.now()
@@ -269,5 +279,10 @@ if __name__ == "__main__":
         action='store_true',
         help='Use unmanaged tables for DeltaLake. This is useful for testing DeltaLake without ' +
         'leveraging a Metastore service.')
+    parser.add_argument(
+        '--hive',
+        action='store_true',
+        help='create Hive external tables for the converted data.'
+    )
     args = parser.parse_args()
     transcode(args)


### PR DESCRIPTION
Signed-off-by: Allen Xu <allxu@nvidia.com>
To close: #109 
This PR supports transcode data to Hive external tables. only `nds_transcode.py` and `nds_power.py` are impacted because Data Maintenance will require either Iceberg or DeltaLake. For Iceberg, it has its own Catalog manage system; For DeltaLake, it already support both managed and unmanaged tables. So the Hive external tables now supports pure data transcode target like Parquet Orc etc.