### PR TITLE
Add a database arg to nds transcode and power with hive

### DIFF
--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -361,7 +361,7 @@ if __name__ == "__main__":
                         'registering temp views.')
     parser.add_argument('--database',
                         default='default',
-                        help='use this database instead of default')
+                        help='use this database instead of default, used together with hive')
     parser.add_argument('--extra_time_log',
                         help='extra path to save time log when running in cloud environment where '+
                         'driver node/pod cannot be accessed easily. User needs to add essential extra ' +

--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -198,7 +198,7 @@ def run_query_stream(input_prefix,
     for easy accesibility. TempView Creation time is also recorded.
 
     Args:
-        input_prefix (str): path of input data or warehouse if input_format is "iceberg".
+        input_prefix (str): path of input data or warehouse if input_format is "iceberg" or hive_external=True.
         query_dict (OrderedDict): ordered dict {query_name: query_content} of all TPC-DS queries runnable in Spark
         time_log_output_path (str): path of the log that contains query execution time, both local
                                     and HDFS path are supported.
@@ -234,7 +234,7 @@ def run_query_stream(input_prefix,
     spark_session = session_builder.appName(
         app_name).getOrCreate()
     if hive_external:
-        spark_session.catalog.setCurrentDatabase(args.database)
+        spark_session.catalog.setCurrentDatabase(input_prefix)
 
     if input_format == 'delta' and delta_unmanaged:
         # Register tables for Delta Lake. This is only needed for unmanaged tables.
@@ -315,7 +315,7 @@ if __name__ == "__main__":
     parser = parser = argparse.ArgumentParser()
     parser.add_argument('input_prefix',
                         help='text to prepend to every input file path (e.g., "hdfs:///ds-generated-data"). ' +
-                        'If input_format is "iceberg", this argument will be regarded as the value of property ' +
+                        'If --hive or if input_format is "iceberg", this argument will be regarded as the value of property ' +
                         '"spark.sql.catalog.spark_catalog.warehouse". Only default Spark catalog ' +
                         'session name "spark_catalog" is supported now, customized catalog is not ' +
                         'yet supported. Note if this points to a Delta Lake table, the path must be ' +
@@ -359,9 +359,6 @@ if __name__ == "__main__":
                         action='store_true',
                         help='use table meta information in Hive metastore directly without ' +
                         'registering temp views.')
-    parser.add_argument('--database',
-                        default='default',
-                        help='use this database instead of default, used together with hive')
     parser.add_argument('--extra_time_log',
                         help='extra path to save time log when running in cloud environment where '+
                         'driver node/pod cannot be accessed easily. User needs to add essential extra ' +

--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -233,6 +233,9 @@ def run_query_stream(input_prefix,
 
     spark_session = session_builder.appName(
         app_name).getOrCreate()
+    if hive_external:
+        spark_session.catalog.setCurrentDatabase(args.database)
+
     if input_format == 'delta' and delta_unmanaged:
         # Register tables for Delta Lake. This is only needed for unmanaged tables.
         execution_time_list = register_delta_tables(spark_session, input_prefix, execution_time_list)
@@ -356,6 +359,9 @@ if __name__ == "__main__":
                         action='store_true',
                         help='use table meta information in Hive metastore directly without ' +
                         'registering temp views.')
+    parser.add_argument('--database',
+                        default='default',
+                        help='use this database instead of default')
     parser.add_argument('--extra_time_log',
                         help='extra path to save time log when running in cloud environment where '+
                         'driver node/pod cannot be accessed easily. User needs to add essential extra ' +

--- a/nds/nds_transcode.py
+++ b/nds/nds_transcode.py
@@ -153,6 +153,9 @@ def transcode(args):
     if args.hive:
         session_builder.enableHiveSupport()
     session = session_builder.appName(f"NDS - transcode - {args.output_format}").getOrCreate()
+    if args.hive:
+        session.sql(f"CREATE DATABASE IF NOT EXISTS {args.database}")
+        session.catalog.setCurrentDatabase(args.database)
     session.sparkContext.setLogLevel(args.log_level)
     results = {}
 
@@ -286,6 +289,11 @@ if __name__ == "__main__":
         '--hive',
         action='store_true',
         help='create Hive external tables for the converted data.'
+    )
+    parser.add_argument(
+        '--database',
+        help='the name of a database to use instead of `default`, currently applies only to Hive',
+        default="default"
     )
     args = parser.parse_args()
     transcode(args)


### PR DESCRIPTION
Fixes #143

- add `--database` arg defaulting to the `default` schema for `--hive` runs of nds_transcode 
- use input_prefix for setCurrentDatabse in `nds_power --hive`  

Signed-off-by: Gera Shegalov <gera@apache.org>