### PR TITLE
Add check for problematic column index for q78

### DIFF
--- a/nds/nds_validate.py
+++ b/nds/nds_validate.py
@@ -238,6 +238,8 @@ def iterate_queries(spark_session: SparkSession,
         sub_input1 = input1 + '/' + query_name
         sub_input2 = input2 + '/' + query_name
         print(f"=== Comparing Query: {query_name} ===")
+        # default it to 2, which is the 2nd column in the query78
+        problematic_col = 2
         if query_name == 'query78':
             problematic_col = check_nth_col_problematic_q78(query_dict[query_name])
         result_equal = compare_results(spark_session,

--- a/nds/nds_validate.py
+++ b/nds/nds_validate.py
@@ -249,7 +249,7 @@ def iterate_queries(spark_session: SparkSession,
                                          input2_format,
                                          ignore_ordering,
                                          query_name == 'query78',
-                                         problematic_col=problematic_col,
+                                         q78_problematic_col=problematic_col,
                                          use_iterator=use_iterator,
                                          max_errors=max_errors,
                                          epsilon=epsilon)


### PR DESCRIPTION
Signed-off-by: Allen Xu <allxu@nvidia.com>
close #101 
This PR adds in a simple parse logic to check which column is the problematic column in q78. Due to the nature of the stream file generation, it's possible that q78 will produce inconsistent outputs. 