### PR TITLE
Support additional transcode input formats

### DIFF
--- a/nds/README.md
+++ b/nds/README.md
@@ -141,7 +141,7 @@ The utility requires a pre-defined [template file](./convert_submit_gpu.template
 necessary Spark configurations. Either user can submit the `nds_transcode.py` directly to spark with
 arbitrary Spark parameters.
 
-CSV, Parquet and ORC are supported for input data format at present.
+CSV is the default input format for data conversion, it can be overridden by `--input_format`.
 
 Parquet, Orc, Avro, JSON and Iceberg are supported for output data format at present with CPU. For GPU conversion,
 only Parquet and Orc are supported.

--- a/nds/README.md
+++ b/nds/README.md
@@ -171,7 +171,8 @@ Arguments for `nds_transcode.py`:
 
 ```bash
 python nds_transcode.py -h
-usage: nds_transcode.py [-h] [--output_mode {overwrite,append,ignore,error,errorifexists}] [--output_format {parquet,orc,avro,json,iceberg,delta}] [--tables TABLES] [--log_level LOG_LEVEL] [--floats] [--update] [--iceberg_write_format {parquet,orc,avro}] [--compression COMPRESSION] [--delta_unmanaged] [--hive]
+usage: nds_transcode.py [-h] [--output_mode {overwrite,append,ignore,error,errorifexists}] [--input_format {csv,parquet,orc}] [--output_format {parquet,orc,avro,json,iceberg,delta}] [--tables TABLES] [--log_level LOG_LEVEL] [--floats] [--update]
+                        [--iceberg_write_format {parquet,orc,avro}] [--compression COMPRESSION] [--delta_unmanaged] [--hive] [--database DATABASE]
                         input_prefix output_prefix report_file
 
 positional arguments:
@@ -185,6 +186,8 @@ optional arguments:
   -h, --help            show this help message and exit
   --output_mode {overwrite,append,ignore,error,errorifexists}
                         save modes as defined by https://spark.apache.org/docs/latest/sql-data-sources-load-save-functions.html#save-modes.default value is errorifexists, which is the Spark default behavior.
+  --input_format {csv,parquet,orc}
+                        input data format to be converted. default value is csv.
   --output_format {parquet,orc,avro,json,iceberg,delta}
                         output data format when converting CSV data sources.
   --tables TABLES       specify table names by a comma separated string. e.g. 'catalog_page,catalog_sales'.
@@ -200,6 +203,7 @@ optional arguments:
   --delta_unmanaged     Use unmanaged tables for DeltaLake. This is useful for testing DeltaLake without leveraging a
                         Metastore service
   --hive                create Hive external tables for the converted data.
+  --database DATABASE   the name of a database to use instead of `default`, currently applies only to Hive
 ```
 
 Example command to submit via `spark-submit-template` utility:

--- a/nds/README.md
+++ b/nds/README.md
@@ -188,7 +188,7 @@ optional arguments:
   -h, --help            show this help message and exit
   --output_mode {overwrite,append,ignore,error,errorifexists}
                         save modes as defined by https://spark.apache.org/docs/latest/sql-data-sources-load-save-functions.html#save-modes.default value is errorifexists, which is the Spark default behavior.
-  --input_format {csv,parquet,orc}
+  --input_format {csv,parquet,orc, avro, json}
                         input data format to be converted. default value is csv.
   --output_format {parquet,orc,avro,json,iceberg,delta}
                         output data format when converting CSV data sources.

--- a/nds/README.md
+++ b/nds/README.md
@@ -141,6 +141,8 @@ The utility requires a pre-defined [template file](./convert_submit_gpu.template
 necessary Spark configurations. Either user can submit the `nds_transcode.py` directly to spark with
 arbitrary Spark parameters.
 
+CSV, Parquet and ORC are supported for input data format at present.
+
 Parquet, Orc, Avro, JSON and Iceberg are supported for output data format at present with CPU. For GPU conversion,
 only Parquet and Orc are supported.
 

--- a/nds/README.md
+++ b/nds/README.md
@@ -173,7 +173,7 @@ Arguments for `nds_transcode.py`:
 
 ```bash
 python nds_transcode.py -h
-usage: nds_transcode.py [-h] [--output_mode {overwrite,append,ignore,error,errorifexists}] [--input_format {csv,parquet,orc}] [--output_format {parquet,orc,avro,json,iceberg,delta}] [--tables TABLES] [--log_level LOG_LEVEL] [--floats] [--update]
+usage: nds_transcode.py [-h] [--output_mode {overwrite,append,ignore,error,errorifexists}] [--input_format {csv,parquet,orc,avro,json}] [--output_format {parquet,orc,avro,json,iceberg,delta}] [--tables TABLES] [--log_level LOG_LEVEL] [--floats] [--update]
                         [--iceberg_write_format {parquet,orc,avro}] [--compression COMPRESSION] [--delta_unmanaged] [--hive] [--database DATABASE]
                         input_prefix output_prefix report_file
 

--- a/nds/nds_transcode.py
+++ b/nds/nds_transcode.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/nds/nds_transcode.py
+++ b/nds/nds_transcode.py
@@ -57,10 +57,10 @@ def load(session, filename, schema, input_format, delimiter="|", header="false",
     data_path = prefix + '/' + filename
     if input_format == 'csv':
         return session.read.option("delimiter", delimiter).option("header", header).csv(data_path, schema=schema)
-    elif input_format in ['parquet', 'orc']:
+    elif input_format in ['parquet', 'orc', 'avro', 'json']:
         return session.read.format(input_format).load(data_path)
     # TODO: all of the output formats should be also supported as input format possibilities
-    # remains 'avro', 'json', 'iceberg', 'delta'
+    # remains 'iceberg', 'delta'
     else:
         raise ValueError("Unsupported input format: {}".format(input_format))
 
@@ -253,7 +253,7 @@ if __name__ == "__main__":
         default="errorifexists")
     parser.add_argument(
         '--input_format',
-        choices=['csv', 'parquet', 'orc'],
+        choices=['csv', 'parquet', 'orc', 'avro', 'json'],
         default='csv',
         help='input data format to be converted. default value is csv.'
     )


### PR DESCRIPTION
Suggested by #155.

Initially add input format support for popular parquet and orc.