### PR TITLE
Bump up javac source/target to 1.8

### DIFF
--- a/nds/tpcds-gen/pom.xml
+++ b/nds/tpcds-gen/pom.xml
@@ -30,6 +30,10 @@
   <name>tpcds-gen</name>
   <url>http://maven.apache.org</url>
 
+  <properties>
+    <tpcds-gen.jdk.version>1.8</tpcds-gen.jdk.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
@@ -62,8 +66,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>${tpcds-gen.jdk.version}</source>
+          <target>${tpcds-gen.jdk.version}</target>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Fixes #162 

verified with 
```bash
JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 mvn clean install 
```

Signed-off-by: Gera Shegalov <gera@apache.org>