### PR TITLE
Exit with nonzero if any task failed

### DIFF
--- a/nds/PysparkBenchReport.py
+++ b/nds/PysparkBenchReport.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/nds/PysparkBenchReport.py
+++ b/nds/PysparkBenchReport.py
@@ -42,7 +42,7 @@ import python_listener
 class PysparkBenchReport:
     """Class to generate json summary report for a benchmark
     """
-    def __init__(self, spark_session: SparkSession) -> None:
+    def __init__(self, spark_session: SparkSession, query_name) -> None:
         self.spark_session = spark_session
         self.summary = {
             'env': {
@@ -54,6 +54,7 @@ class PysparkBenchReport:
             'exceptions': [],
             'startTime': None,
             'queryTimes': [],
+            'query': query_name,
         }
 
     def report_on(self, fn: Callable, *args):
@@ -106,7 +107,7 @@ class PysparkBenchReport:
                 listener.unregister()
             return self.summary
 
-    def write_summary(self, query_name, prefix=""):
+    def write_summary(self, prefix=""):
         """_summary_
 
         Args:
@@ -115,8 +116,12 @@ class PysparkBenchReport:
         """
         # Power BI side is retrieving some information from the summary file name, so keep this file
         # name format for pipeline compatibility
-        self.summary['query'] = query_name
-        filename = prefix + '-' + query_name + '-' +str(self.summary['startTime']) + '.json'
+        filename = prefix + '-' + self.summary['query'] + '-' +str(self.summary['startTime']) + '.json'
         self.summary['filename'] = filename
         with open(filename, "w") as f:
             json.dump(self.summary, f, indent=2)
+
+    def is_success(self):
+        """Check if the query succeeded, queryStatus == Completed
+        """
+        return self.summary['queryStatus'] == 'Completed'

--- a/nds/PysparkBenchReport.py
+++ b/nds/PysparkBenchReport.py
@@ -124,4 +124,4 @@ class PysparkBenchReport:
     def is_success(self):
         """Check if the query succeeded, queryStatus == Completed
         """
-        return self.summary['queryStatus'] == 'Completed'
+        return self.summary['queryStatus'][0] == 'Completed'

--- a/nds/nds_maintenance.py
+++ b/nds/nds_maintenance.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/nds/nds_maintenance.py
+++ b/nds/nds_maintenance.py
@@ -223,7 +223,7 @@ def run_query(spark_session,
         # show query name in Spark web UI
         spark_session.sparkContext.setJobGroup(query_name, query_name)
         print(f"====== Run {query_name} ======")
-        q_report = PysparkBenchReport(spark_session)
+        q_report = PysparkBenchReport(spark_session, query_name)
         summary = q_report.report_on(run_dm_query, spark_session,
                                                        q_content,
                                                        query_name,
@@ -237,7 +237,7 @@ def run_query(spark_session,
                     json_summary_folder, os.path.basename(property_file).split('.')[0])
             else:
                 summary_prefix =  os.path.join(json_summary_folder, '')
-            q_report.write_summary(query_name, prefix=summary_prefix)
+            q_report.write_summary(prefix=summary_prefix)
     if not keep_sc:
         spark_session.sparkContext.stop()
     DM_end = datetime.now()

--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -315,10 +315,10 @@ def run_query_stream(input_prefix,
                 print("====== Queries with failure ======")
             print("{} status: {}".format(q.summary['query'], q.summary['queryStatus']))
             exit_code = 1
-    if not exit_code:
+    if exit_code:
         print("Above queries failed or completed with failed tasks. Please check the logs for the detailed reason.")
 
-    if not allow_failure:
+    if not allow_failure and exit_code:
         sys.exit(exit_code)
 
 def load_properties(filename):

--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -311,7 +311,7 @@ def run_query_stream(input_prefix,
         exit_code = 0
         for q in queries_reports:
             if not q.is_success():
-                print("{} status: {}".format(q.summary['query'], q.summary['queryStatus'])
+                print("{} status: {}".format(q.summary['query'], q.summary['queryStatus']))
                 exit_code = 1
         sys.exit(exit_code)
 

--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -308,7 +308,7 @@ def run_query_stream(input_prefix,
         time_df.coalesce(1).write.csv(extra_time_log_output_path)
 
     if not nofailure:
-        # check queries_reports, if there's any task or query failed, exit a non-zero to represent nofailure
+        # check queries_reports, if there's any task or query failed, exit a non-zero to represent the script failure
         exit_code = 0
         for q in queries_reports:
             if not q.is_success():

--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -193,7 +193,8 @@ def run_query_stream(input_prefix,
                      json_summary_folder=None,
                      delta_unmanaged=False,
                      keep_sc=False,
-                     hive_external=False):
+                     hive_external=False,
+                     nofailure=False):
     """run SQL in Spark and record execution time log. The execution time log is saved as a CSV file
     for easy accesibility. TempView Creation time is also recorded.
 
@@ -209,6 +210,7 @@ def run_query_stream(input_prefix,
         output_format (str, optional): query output format, choices are csv, orc, parquet. Defaults
         to "parquet".
     """
+    queries_reports = []
     execution_time_list = []
     total_time_start = time.time()
     # check if it's running specific query or Power Run
@@ -253,7 +255,7 @@ def run_query_stream(input_prefix,
         # show query name in Spark web UI
         spark_session.sparkContext.setJobGroup(query_name, query_name)
         print("====== Run {} ======".format(query_name))
-        q_report = PysparkBenchReport(spark_session)
+        q_report = PysparkBenchReport(spark_session, query_name)
         summary = q_report.report_on(run_one_query,spark_session,
                                                    q_content,
                                                    query_name,
@@ -262,6 +264,7 @@ def run_query_stream(input_prefix,
         print(f"Time taken: {summary['queryTimes']} millis for {query_name}")
         query_times = summary['queryTimes']
         execution_time_list.append((spark_app_id, query_name, query_times[0]))
+        queries_reports.append(q_report)
         if json_summary_folder:
             # property_file e.g.: "property/aqe-on.properties" or just "aqe-off.properties"
             if property_file:
@@ -269,7 +272,7 @@ def run_query_stream(input_prefix,
                     json_summary_folder, os.path.basename(property_file).split('.')[0])
             else:
                 summary_prefix =  os.path.join(json_summary_folder, '')
-            q_report.write_summary(query_name, prefix=summary_prefix)
+            q_report.write_summary(prefix=summary_prefix)
     power_end = int(time.time())
     power_elapse = int((power_end - power_start)*1000)
     if not keep_sc:
@@ -302,6 +305,15 @@ def run_query_stream(input_prefix,
         spark_session = SparkSession.builder.getOrCreate()
         time_df = spark_session.createDataFrame(data=execution_time_list, schema = header)
         time_df.coalesce(1).write.csv(extra_time_log_output_path)
+
+    if not nofailure:
+        # check queries_reports, if there's any task or query failed, exit a non-zero to represent nofailure
+        exit_code = 0
+        for q in queries_reports:
+            if not q.is_success():
+                print("{} status: {}".format(q.summary['query'], q.summary['queryStatus'])
+                exit_code = 1
+        sys.exit(exit_code)
 
 def load_properties(filename):
     myvars = {}
@@ -364,13 +376,15 @@ if __name__ == "__main__":
                         'driver node/pod cannot be accessed easily. User needs to add essential extra ' +
                         'jars and configurations to access different cloud storage systems. ' +
                         'e.g. s3, gs etc.')
-
     parser.add_argument('--sub_queries',
                         type=lambda s: [x.strip() for x in s.split(',')],
                         help='comma separated list of queries to run. If not specified, all queries ' +
                         'in the stream file will be run. e.g. "query1,query2,query3". Note, use ' +
                         '"_part1" and "_part2" suffix for the following query names: ' +
                         'query14, query23, query24, query39. e.g. query14_part1, query39_part2')
+    parser.add_argument('--nofailure',
+                        action='store_true',
+                        help='Do not exit with non zero when any query failed or any task failed')
     args = parser.parse_args()
     query_dict = gen_sql_from_stream(args.query_stream_file)
     run_query_stream(args.input_prefix,
@@ -386,4 +400,5 @@ if __name__ == "__main__":
                      args.json_summary_folder,
                      args.delta_unmanaged,
                      args.keep_sc,
-                     args.hive)
+                     args.hive,
+                     args.nofailure)

--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -312,10 +312,12 @@ def run_query_stream(input_prefix,
         exit_code = 0
         for q in queries_reports:
             if not q.is_success():
+                if exit_code == 0:
+                    print("====== Queries with failure ======")
                 print("{} status: {}".format(q.summary['query'], q.summary['queryStatus']))
                 exit_code = 1
         if exit_code == 1:
-            print("Above queries failed or completed with failed tasks.")
+            print("Above queries failed or completed with failed tasks. Please check the logs for the detailed reason.")
             sys.exit(exit_code)
 
 def load_properties(filename):

--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -33,6 +33,7 @@
 import argparse
 import csv
 import os
+import sys
 import time
 from collections import OrderedDict
 from pyspark.sql import SparkSession
@@ -313,7 +314,9 @@ def run_query_stream(input_prefix,
             if not q.is_success():
                 print("{} status: {}".format(q.summary['query'], q.summary['queryStatus']))
                 exit_code = 1
-        sys.exit(exit_code)
+        if exit_code == 1:
+            print("Above queries failed or completed with failed tasks.")
+            sys.exit(exit_code)
 
 def load_properties(filename):
     myvars = {}

--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -316,7 +316,7 @@ def run_query_stream(input_prefix,
                     print("====== Queries with failure ======")
                 print("{} status: {}".format(q.summary['query'], q.summary['queryStatus']))
                 exit_code = 1
-        if exit_code == 1:
+        if not exit_code:
             print("Above queries failed or completed with failed tasks. Please check the logs for the detailed reason.")
             sys.exit(exit_code)
 


### PR DESCRIPTION
Add an arg '--allow_failure'
Save the query reports into an array
Check the query reports after running and exit with non-zero value to represent a failure of the script if no flag '--allow_failure'
Print out the query which status is 'Failed' or 'CompletedWithFailedTask'

Close #147 