### PR TITLE
Use ISO-8859 codec to load CSV files

### DIFF
--- a/nds/nds_transcode.py
+++ b/nds/nds_transcode.py
@@ -56,7 +56,8 @@ TABLE_PARTITIONING = {
 def load(session, filename, schema, input_format, delimiter="|", header="false", prefix=""):
     data_path = prefix + '/' + filename
     if input_format == 'csv':
-        return session.read.option("delimiter", delimiter).option("header", header).csv(data_path, schema=schema)
+        return session.read.option("delimiter", delimiter).option("header", header)\
+            .option("encoding", "ISO-8859-1").csv(data_path, schema=schema)
     elif input_format in ['parquet', 'orc', 'avro', 'json']:
         return session.read.format(input_format).load(data_path)
     # TODO: all of the output formats should be also supported as input format possibilities


### PR DESCRIPTION
To close #170 .

before this change:
```
// df for "customer" table
scala> df.select("c_birth_country").filter(df("c_birth_country").contains("IVOIRE"))show()
+---------------+
|c_birth_country|
+---------------+
|  C�TE D'IVOIRE|
...
+---------------+
```
after:
```
// df for "customer" table
scala> df.select("c_birth_country").filter(df("c_birth_country").contains("IVOIRE"))show()
+---------------+
|c_birth_country|
+---------------+
|  CÔTE D'IVOIRE|
...
+---------------+
```

One concern for this change: 
we only support UTF-8 encoded data loading for CSV(https://github.com/NVIDIA/spark-rapids/blob/branch-23.12/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuCSVScan.scala#L121). We may see performance drop when converting with the spark-rapids plugin.
A better solution is to check special characters for all tables, we only specify ISO-8859 for tables that contain those international characters. I will check how many tables have such issue. If not many, I'll apply this specific process.