### PR TITLE
Support data maintenance on Delta managed tables

### DIFF
--- a/nds/nds_maintenance.py
+++ b/nds/nds_maintenance.py
@@ -110,6 +110,9 @@ def create_spark_session(valid_queries, warehouse_path, warehouse_type):
     else:
         app_name = "NDS - Data Maintenance"
     spark_session_builder = SparkSession.builder
+    if warehouse_type == "delta":
+        # now we only support managed table(by Hive Metastore) for Data Maintenance
+        spark_session_builder.config("spark.sql.catalogImplementation", "hive")
     if warehouse_type == "iceberg":
         spark_session_builder.config("spark.sql.catalog.spark_catalog.warehouse", warehouse_path)
     spark_session = spark_session_builder.appName(app_name).getOrCreate()


### PR DESCRIPTION
Close: #175 

As titled.

To support data maintenance process over Delta managed tables.

Configure the catalog type to Hive, so spark is able to find tables metadata from Hive metastore and won't throw errors for "table not found".