### PR TITLE
Throughput run uses individual template in full benchmark

### DIFF
--- a/nds/README.md
+++ b/nds/README.md
@@ -517,4 +517,11 @@ positional arguments:
   yaml_config  yaml config file for the benchmark
 ```
 
+NOTE: For Throughput Run, user should create a new template file based on the one used for Power Run.
+The only difference between them is that the template for Throughput Run should limit the compute resource
+based on the number of streams used in the Throughput Run.
+For instance: 4 concurrent streams in one Throughput run and the total available cores in the benchmark cluster
+are 1024. Then in the template, `spark.cores.max` should be set to `1024/4=256` so that each stream will have
+compute resource evenly.
+
 ### NDS2.0 is using source code from TPC-DS Tool V3.2.0

--- a/nds/bench.yml
+++ b/nds/bench.yml
@@ -30,6 +30,7 @@ power_test: # use load test output as input to avoid duplication
   output_path: # leave it empty to use "collect" as Spark action. Otherwise it can be used for data validation
   skip: false
 throughput_test: # use most parameters from power test to avoid duplication
+  spark_template_path: throughput_run_gpu_iceberg.template # user can copy the one used for Power run and add resource limit
   report_base_path: throughput_report
   skip: false
 maintenance_test:

--- a/nds/nds_bench.py
+++ b/nds/nds_bench.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -387,6 +387,7 @@ def run_full_bench(yaml_params):
     power_property_path = yaml_params['power_test']['property_path']
     power_output_path = yaml_params['power_test']['output_path']
     skip_throughput_test = yaml_params['throughput_test']['skip']
+    throughput_template_path = yaml_params['throughput_test']['spark_template_path']
     throughput_report_base = yaml_params['throughput_test']['report_base_path']
     # temaplte to write to parquet, with GPU
     skip_maintenance_test = yaml_params['maintenance_test']['skip']
@@ -434,7 +435,7 @@ def run_full_bench(yaml_params):
     if not skip_throughput_test:
         throughput_test(num_streams,
                         1,
-                        power_template_path,
+                        throughput_template_path,
                         warehouse_output_path,
                         stream_output_path,
                         throughput_report_base,
@@ -460,7 +461,7 @@ def run_full_bench(yaml_params):
     if not skip_throughput_test:
         throughput_test(num_streams,
                         2,
-                        power_template_path,
+                        throughput_template_path,
                         warehouse_output_path,
                         stream_output_path,
                         throughput_report_base,


### PR DESCRIPTION
close #174 
As titled.

This PR adds in a new config for throughput run template file. This template file should have resource limit to allow concurrent streams during throughput test.

To avoid too many template files and also considering the highly overlap content between that and power run template, we don't adds in additional template files. User can copy the one for Power Run directly and add resource limit.