### PR TITLE
Add -N to skip the input wait for patching

### DIFF
--- a/nds/tpcds-gen/Makefile
+++ b/nds/tpcds-gen/Makefile
@@ -31,7 +31,7 @@ target/tools/dsdgen: check-env
 	mkdir -p target/
 	cp patches/*.patch $(TPCDS_HOME)/
 	# unapply previously applied patches if any, ignore errors
-	-cd $(TPCDS_HOME); cat *.patch | patch -R -p1
+	-cd $(TPCDS_HOME); cat *.patch | patch -R -p1 -N
 	# apply patches to both source code and templates
 	cd $(TPCDS_HOME) && cat *.patch | patch -p1
 	test -d target/tools/ || (cd target; cp -r $(TPCDS_HOME)/tools tools)


### PR DESCRIPTION
The original command used "cat *.patch | patch -R -p1" to unapply the patches first, but at the first running, there's no matched patch changes in the source code, so it'll ask for user input to confirm.

Use "-N" to make the command silent to skip the user input.

Close https://github.com/NVIDIA/spark-rapids-benchmarks/issues/173