### PR TITLE
Use Delta 1.1.0 for Spark 3.2.x

### DIFF
--- a/nds/README.md
+++ b/nds/README.md
@@ -175,6 +175,9 @@ when you are about to shutdown the Metastore service.
 For [unmanaged tables](https://docs.databricks.com/lakehouse/data-objects.html#what-is-an-unmanaged-table),
 user doesn't need to create the Metastore service,  appending `--delta_unmanaged` to arguments will be enough.
 
+NOTE: To enabling Delta against different Spark versions, please modify the Delta package version accordingly in the template file.
+For more version compatibility information, please visit [compatibility with apache spark](https://docs.delta.io/latest/releases.html#compatibility-with-apache-spark)
+
 Arguments for `nds_transcode.py`:
 
 ```bash

--- a/nds/README.md
+++ b/nds/README.md
@@ -176,7 +176,7 @@ For [unmanaged tables](https://docs.databricks.com/lakehouse/data-objects.html#w
 user doesn't need to create the Metastore service,  appending `--delta_unmanaged` to arguments will be enough.
 
 NOTE: To enabling Delta against different Spark versions, please modify the Delta package version accordingly in the template file.
-For more version compatibility information, please visit [compatibility with apache spark](https://docs.delta.io/latest/releases.html#compatibility-with-apache-spark)
+For more version compatibility information, please visit [compatibility with apache spark](https://docs.delta.io/latest/releases.html#compatibility-with-apache-spark).
 
 Arguments for `nds_transcode.py`:
 

--- a/nds/convert_submit_cpu_delta.template
+++ b/nds/convert_submit_cpu_delta.template
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-# 1. The io.delta:delta-core_2.12:1.0.1 only works on Spark 3.1.x
+# 1. The io.delta:delta-core_2.12:1.1.0 only works on Spark 3.2.x
 #    Please refer to https://docs.delta.io/latest/releases.html for other Spark versions.
 
 source base.template
@@ -28,6 +28,6 @@ export SPARK_CONF=("--master" "${SPARK_MASTER}"
                    "--conf" "spark.executor.instances=${NUM_EXECUTORS}"
                    "--conf" "spark.executor.memory=${EXECUTOR_MEMORY}"
                    "--conf" "spark.sql.shuffle.partitions=${SHUFFLE_PARTITIONS}"
-                   "--packages" "io.delta:delta-core_2.12:1.0.1"
+                   "--packages" "io.delta:delta-core_2.12:1.1.0"
                    "--conf" "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension"
                    "--conf" "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog")

--- a/nds/maintenance_delta.template
+++ b/nds/maintenance_delta.template
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-# 1. The io.delta:delta-core_2.12:1.0.0 only works on Spark 3.1.x
+# 1. The io.delta:delta-core_2.12:1.1.0 only works on Spark 3.2.x
 #    Please refer to https://docs.delta.io/latest/releases.html for other Spark versions.
 
 source base.template
@@ -29,7 +29,7 @@ export SPARK_CONF=("--master" "${SPARK_MASTER}"
                    "--conf" "spark.executor.instances=${NUM_EXECUTORS}"
                    "--conf" "spark.executor.memory=${EXECUTOR_MEMORY}"
                    "--conf" "spark.sql.shuffle.partitions=${SHUFFLE_PARTITIONS}"
-                   "--packages" "io.delta:delta-core_2.12:1.0.1"
+                   "--packages" "io.delta:delta-core_2.12:1.1.0"
                    "--conf" "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension"
                    "--conf" "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog"
                    "--jars" "$NDS_LISTENER_JAR")

--- a/nds/power_run_cpu_delta.template
+++ b/nds/power_run_cpu_delta.template
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-# 1. The io.delta:delta-core_2.12:1.0.1 only works on Spark 3.1.x
+# 1. The io.delta:delta-core_2.12:1.1.0 only works on Spark 3.2.x
 #    Please refer to https://docs.delta.io/latest/releases.html for other Spark versions.
 
 source base.template
@@ -28,7 +28,7 @@ export SPARK_CONF=("--master" "${SPARK_MASTER}"
                    "--conf" "spark.executor.instances=${NUM_EXECUTORS}"
                    "--conf" "spark.executor.memory=${EXECUTOR_MEMORY}"
                    "--conf" "spark.sql.shuffle.partitions=${SHUFFLE_PARTITIONS}"
-                   "--packages" "io.delta:delta-core_2.12:1.0.1"
+                   "--packages" "io.delta:delta-core_2.12:1.1.0"
                    "--conf" "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension"
                    "--conf" "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog"
                    "--jars" "$NDS_LISTENER_JAR")

--- a/nds/power_run_gpu_delta.template
+++ b/nds/power_run_gpu_delta.template
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-# 1. The io.delta:delta-core_2.12:1.0.1 only works on Spark 3.1.x
+# 1. The io.delta:delta-core_2.12:1.1.0 only works on Spark 3.2.x
 #    Please refer to https://docs.delta.io/latest/releases.html for other Spark versions.
 
 source base.template
@@ -39,7 +39,7 @@ export SPARK_CONF=("--master" "${SPARK_MASTER}"
                    "--conf" "spark.rapids.memory.host.spillStorageSize=32G"
                    "--conf" "spark.rapids.memory.pinnedPool.size=8g"
                    "--conf" "spark.rapids.sql.concurrentGpuTasks=${CONCURRENT_GPU_TASKS}"
-                   "--packages" "io.delta:delta-core_2.12:1.0.1"
+                   "--packages" "io.delta:delta-core_2.12:1.1.0"
                    "--conf" "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension"
                    "--conf" "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog"
                    "--files" "$SPARK_HOME/examples/src/main/scripts/getGpusResources.sh"


### PR DESCRIPTION
As title.

To fix #191 
- Change Delta version to 1.1.0 to be compatible with Spark3.2.0 (spark-rapids drop support for 3.1.x since 24.08)
- Add note in README
