### PR TITLE
Add support for profiling hooks on CPU.

### DIFF
--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -447,8 +447,8 @@ if __name__ == "__main__":
                         action='store_true',
                         help='Do not exit with non zero when any query failed or any task failed')
     parser.add_argument('--profiling_hook',
-                        help='Executable that is called just before/after a query starts executing.' +
-                        'Executable is called like this ' +
+                        help='Executable that is called just before/after a query executes.' +
+                        'The executable is called like this ' +
                         './hook {start|stop} output_directory query_name.')
     args = parser.parse_args()
     query_dict = gen_sql_from_stream(args.query_stream_file)

--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
This PR adds the capability of profiling individual queries on CPU without prescribing the used profiling tools.
The workflow is very simple.
The user provides a `--profiling-hook [executable]` argument to nds_power.py. *executable* here is a script that gets called before and after each query. When the query starts, the first argument is `start`, when it stops, the first argument is `stop`.

For example, a user can decide to start perf, attach a profiler, etc.