### PR TITLE
Add support for warmups and iterations for each query

### DIFF
--- a/nds-h/nds_h_power.py
+++ b/nds-h/nds_h_power.py
@@ -186,6 +186,8 @@ def run_query_stream(input_prefix,
                      query_dict,
                      time_log_output_path,
                      sub_queries,
+                     warmup_iterations,
+                     iterations,
                      input_format,
                      output_path=None,
                      keep_sc=False,
@@ -237,7 +239,10 @@ def run_query_stream(input_prefix,
         spark_session.sparkContext.setJobGroup(query_name, query_name)
         print("====== Run {} ======".format(query_name))
         q_report = PysparkBenchReport(spark_session, query_name)
-        summary = q_report.report_on(run_one_query, spark_session,
+        summary = q_report.report_on(run_one_query,
+                                     warmup_iterations,
+                                     iterations,
+                                     spark_session,
                                      q_content,
                                      query_name,
                                      output_path,
@@ -346,6 +351,14 @@ if __name__ == "__main__":
                         default='parquet')
     parser.add_argument('--property_file',
                         help='property file for Spark configuration.')
+    parser.add_argument('--warmup_iterations',
+                        type=int,
+                        help='Number of warmup iterations for each query.',
+                        default=0)
+    parser.add_argument('--iterations',
+                        type=int,
+                        help='Number of iterations for each query.',
+                        default=1)
     args = parser.parse_args()
     query_dict = gen_sql_from_stream(args.query_stream_file)
     run_query_stream(args.input_prefix,
@@ -353,6 +366,8 @@ if __name__ == "__main__":
                      query_dict,
                      args.time_log,
                      args.sub_queries,
+                     args.warmup_iterations,
+                     args.iterations,
                      args.input_format,
                      args.output_prefix,
                      args.keep_sc,

--- a/nds-h/nds_h_power.py
+++ b/nds-h/nds_h_power.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/nds/PysparkBenchReport.py
+++ b/nds/PysparkBenchReport.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/nds/PysparkBenchReport.py
+++ b/nds/PysparkBenchReport.py
@@ -57,7 +57,7 @@ class PysparkBenchReport:
             'query': query_name,
         }
 
-    def report_on(self, fn: Callable, *args):
+    def report_on(self, fn: Callable, warmup_iterations = 0, iterations = 1, *args):
         """Record a function for its running environment, running status etc. and exclude sentive
         information like tokens, secret and password Generate summary in dict format for it.
 
@@ -84,28 +84,41 @@ class PysparkBenchReport:
         if listener is not None:
             print("TaskFailureListener is registered.")
         try:
-            start_time = int(time.time() * 1000)
-            fn(*args)
-            end_time = int(time.time() * 1000)
-            if listener and len(listener.failures) != 0:
-                self.summary['queryStatus'].append("CompletedWithTaskFailures")
-            else:
-                self.summary['queryStatus'].append("Completed")
+            # warmup
+            for i in range(0, warmup_iterations):
+                fn(*args)
         except Exception as e:
-            # print the exception to ease debugging
-            print('ERROR BEGIN')
+            print('ERROR WHILE WARMUP BEGIN')
             print(e)
             traceback.print_tb(e.__traceback__)
-            print('ERROR END')
-            end_time = int(time.time() * 1000)
-            self.summary['queryStatus'].append("Failed")
-            self.summary['exceptions'].append(str(e))
-        finally:
-            self.summary['startTime'] = start_time
-            self.summary['queryTimes'].append(end_time - start_time)
-            if listener is not None:
-                listener.unregister()
-            return self.summary
+            print('ERROR WHILE WARMUP END')
+
+        start_time = int(time.time() * 1000)
+        self.summary['startTime'] = start_time
+        # run the query
+        for i in range(0, iterations):
+            try:    
+                start_time = int(time.time() * 1000)
+                fn(*args)
+                end_time = int(time.time() * 1000)
+                if listener and len(listener.failures) != 0:
+                    self.summary['queryStatus'].append("CompletedWithTaskFailures")
+                else:
+                    self.summary['queryStatus'].append("Completed")
+            except Exception as e:
+                # print the exception to ease debugging
+                print('ERROR BEGIN')
+                print(e)
+                traceback.print_tb(e.__traceback__)
+                print('ERROR END')
+                end_time = int(time.time() * 1000)
+                self.summary['queryStatus'].append("Failed")
+                self.summary['exceptions'].append(str(e))
+            finally:
+                self.summary['queryTimes'].append(end_time - start_time)
+        if listener is not None:
+            listener.unregister()
+        return self.summary
 
     def write_summary(self, prefix=""):
         """_summary_

--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -231,6 +231,8 @@ def run_query_stream(input_prefix,
                      time_log_output_path,
                      extra_time_log_output_path,
                      sub_queries,
+                     warmup_iterations,
+                     iterations,
                      input_format="parquet",
                      use_decimal=True,
                      output_path=None,
@@ -306,7 +308,9 @@ def run_query_stream(input_prefix,
         spark_session.sparkContext.setJobGroup(query_name, query_name)
         print("====== Run {} ======".format(query_name))
         q_report = PysparkBenchReport(spark_session, query_name)
-        summary = q_report.report_on(run_one_query,spark_session,
+        summary = q_report.report_on(run_one_query,warmup_iterations,
+                                                   iterations,
+                                                   spark_session,
                                                    profiler,
                                                    q_content,
                                                    query_name,
@@ -314,7 +318,8 @@ def run_query_stream(input_prefix,
                                                    output_format)
         print(f"Time taken: {summary['queryTimes']} millis for {query_name}")
         query_times = summary['queryTimes']
-        execution_time_list.append((spark_app_id, query_name, query_times[0]))
+        for query_time in query_times:
+            execution_time_list.append((spark_app_id, query_name, query_time))
         queries_reports.append(q_report)
         if json_summary_folder:
             # property_file e.g.: "property/aqe-on.properties" or just "aqe-off.properties"
@@ -445,6 +450,14 @@ if __name__ == "__main__":
                         help='Executable that is called just before/after a query executes.' +
                         'The executable is called like this ' +
                         './hook {start|stop} output_root query_name.')
+    parser.add_argument('--warmup_iterations',
+                        type=int,
+                        help='Number of warmup iterations for each query.',
+                        default=0)
+    parser.add_argument('--iterations',
+                        type=int,
+                        help='Number of iterations for each query.',
+                        default=1)
     args = parser.parse_args()
     query_dict = gen_sql_from_stream(args.query_stream_file)
     run_query_stream(args.input_prefix,
@@ -453,6 +466,8 @@ if __name__ == "__main__":
                      args.time_log,
                      args.extra_time_log,
                      args.sub_queries,
+                     args.warmup_iterations,
+                     args.iterations,
                      args.input_format,
                      not args.floats,
                      args.output_prefix,


### PR DESCRIPTION
This PR proposes to add support for two new optional arguments, `warmup_iterations` and `iterations`.

- `warmup_iterations` specifies the number of warmup iterations for each query to run before its performance is measured. The warmup timings are not reported. This is set to 0 by default.
- `iterations` specifies the number of iterations for each query to run and measure its performance. This is set to 1 by default.

An example snippet of the report with `warmup_iterations=3` and `iterations=5`:

```
...
local-1741649529813,CreateTempView catalog_sales,2245
local-1741649529813,CreateTempView store_sales,1697
local-1741649529813,query1,874
local-1741649529813,query1,952
local-1741649529813,query1,763
local-1741649529813,query1,860
local-1741649529813,query1,752
local-1741649529813,Power Start Time,1741649555
local-1741649529813,Power End Time,1741649565
local-1741649529813,Power Test Time,10000
local-1741649529813,Total Time,38532
...
```

But the `query1` ran 8 times as intended (3 warmups, 5 actual runs).

![Screenshot 2025-03-10 at 4 34 03 PM](https://github.com/user-attachments/assets/bd1331bd-7d61-4b68-b699-ad5338c6ec31)

These new arguments are optional, and thus they do not change existing behaviors when they are not set. When they are set, the power run script runs each query `warmup_iterations` times first, and then `iterations` times to measure timings. Only the timings after the warmup are reported. 

Unlike the existing `runs` argument that specifies the number of power runs to run, these new arguments specify per-query iterations. In Spark terms, the `runs` argument can submit multiple Spark applications where each application performs one power run, while the new arguments specifies the number of iterations for each query to run in the same Spark application. This could be useful especially when you want to keep some states between multiple query runs in Spark, such as file cache, to get more consistent results.