### PR TITLE
Remove warmup_iterations and iterations arguments for nds-h

### DIFF
--- a/nds-h/nds_h_power.py
+++ b/nds-h/nds_h_power.py
@@ -186,8 +186,6 @@ def run_query_stream(input_prefix,
                      query_dict,
                      time_log_output_path,
                      sub_queries,
-                     warmup_iterations,
-                     iterations,
                      input_format,
                      output_path=None,
                      keep_sc=False,
@@ -240,8 +238,6 @@ def run_query_stream(input_prefix,
         print("====== Run {} ======".format(query_name))
         q_report = PysparkBenchReport(spark_session, query_name)
         summary = q_report.report_on(run_one_query,
-                                     warmup_iterations,
-                                     iterations,
                                      spark_session,
                                      q_content,
                                      query_name,
@@ -351,14 +347,6 @@ if __name__ == "__main__":
                         default='parquet')
     parser.add_argument('--property_file',
                         help='property file for Spark configuration.')
-    parser.add_argument('--warmup_iterations',
-                        type=int,
-                        help='Number of warmup iterations for each query.',
-                        default=0)
-    parser.add_argument('--iterations',
-                        type=int,
-                        help='Number of iterations for each query.',
-                        default=1)
     args = parser.parse_args()
     query_dict = gen_sql_from_stream(args.query_stream_file)
     run_query_stream(args.input_prefix,
@@ -366,8 +354,6 @@ if __name__ == "__main__":
                      query_dict,
                      args.time_log,
                      args.sub_queries,
-                     args.warmup_iterations,
-                     args.iterations,
                      args.input_format,
                      args.output_prefix,
                      args.keep_sc,


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/spark-rapids-benchmarks/issues/204.

The issue is that the `PysparkBenchReport` class `nds_h_power.py` uses is `util/python_benchmark_reporter/PysparkBenchReport.py`, whereas the `PysparkBenchReport` class modified in https://github.com/NVIDIA/spark-rapids-benchmarks/pull/202 is `nds/PysparkBenchReport.py`. As the former was not modified to support new arguments, the nds_h script fails. I rather reverted my change for nds-h in this PR than fixing the `util/python_benchmark_reporter/PysparkBenchReport.py` file. It seems strange to have duplicate classes, one for nds and another for nds-h. We should just consolidate them.