### PR TITLE
Cleanup files instead of failing if json summary folder exists

### DIFF
--- a/nds/check.py
+++ b/nds/check.py
@@ -140,9 +140,11 @@ def check_json_summary_folder(json_summary_folder):
             os.makedirs(json_summary_folder)
         else:
             if os.listdir(json_summary_folder):
-                raise Exception(f"json_summary_folder {json_summary_folder} is not empty. " +
-                                "There may be already some json files there. Please clean the folder " +
-                                "or specify another one.")
+                # Remove all contents from the existing folder
+                for item in os.listdir(json_summary_folder):
+                    item_path = os.path.join(json_summary_folder, item)
+                    if os.path.isfile(item_path):
+                        os.remove(item_path)
 
 def check_query_subset_exists(query_dict, subset_list):
     """check if the query subset exists in the query dictionary"""

--- a/nds/check.py
+++ b/nds/check.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Scope: change logic for scenario where JSON summary folder already exists to remove files inside directory instead of failing.  This is relevant for Aether testing for NDS benchmarks.