### PR TITLE
Add support for delta unmanaged tables for NDS-H

### DIFF
--- a/nds-h/nds_h_power.py
+++ b/nds-h/nds_h_power.py
@@ -122,7 +122,7 @@ def setup_tables(spark_session, input_prefix, input_format, execution_time_list)
 def register_delta_tables(spark_session, input_prefix, execution_time_list):
     spark_app_id = spark_session.sparkContext.applicationId
     # Register tables for Delta Lake
-    for table_name in get_schemas(False).keys():
+    for table_name in get_schemas().keys():
         start = int(time.time() * 1000)
         # input_prefix must be absolute path: https://github.com/delta-io/delta/issues/555
         register_sql = f"CREATE TABLE IF NOT EXISTS {table_name} USING DELTA LOCATION '{input_prefix}/{table_name}'"

--- a/nds-h/nds_h_power.py
+++ b/nds-h/nds_h_power.py
@@ -119,6 +119,23 @@ def setup_tables(spark_session, input_prefix, input_format, execution_time_list)
     return execution_time_list
 
 
+def register_delta_tables(spark_session, input_prefix, execution_time_list):
+    spark_app_id = spark_session.sparkContext.applicationId
+    # Register tables for Delta Lake
+    for table_name in get_schemas(False).keys():
+        start = int(time.time() * 1000)
+        # input_prefix must be absolute path: https://github.com/delta-io/delta/issues/555
+        register_sql = f"CREATE TABLE IF NOT EXISTS {table_name} USING DELTA LOCATION '{input_prefix}/{table_name}'"
+        print(register_sql)
+        spark_session.sql(register_sql)
+        end = int(time.time() * 1000)
+        print("====== Registering for table {} ======".format(table_name))
+        print("Time taken: {} millis for table {}".format(end - start, table_name))
+        execution_time_list.append(
+            (spark_app_id, "Register {}".format(table_name), end - start))
+    return execution_time_list
+
+
 def ensure_valid_column_names(df: DataFrame):
     def is_column_start(char):
         return char.isalpha() or char == '_'
@@ -254,6 +271,9 @@ def run_query_stream(input_prefix,
     if input_format != 'iceberg' and input_format != 'delta':
         execution_time_list = setup_tables(spark_session, input_prefix, input_format,
                                            execution_time_list)
+    elif input_format == 'delta':
+        execution_time_list = register_delta_tables(spark_session, input_prefix,
+                                                     execution_time_list)
 
     check_json_summary_folder(json_summary_folder)
     if sub_queries:


### PR DESCRIPTION
This PR adds support for delta unmanaged tables for NDS-H. As for delta managed tables, I am planning to make a follow-up PR for them. The new function `register_delta_tables` is copied over from `nds_power.py` and slightly modified for nds-h. As such, this is introducing another piece of duplicated code in this repo. We will fix this issue in https://github.com/NVIDIA/spark-rapids-benchmarks/issues/217.