### PR TITLE
Remove hard-coded query number in query parsing for NDS-H

### DIFF
--- a/nds-h/nds_h_power.py
+++ b/nds-h/nds_h_power.py
@@ -76,14 +76,12 @@ def gen_sql_from_stream(query_stream_file_path):
     # Populate the dictionary with template file numbers as keys and queries as values
     for match in matches:
         template_number = match[0]
-        if int(template_number) == 15:
-            new_queries = match[1].split(";")
-            extended_queries[f'query{template_number}_part1'] = new_queries[0].strip()
-            extended_queries[f'query{template_number}_part2'] = new_queries[1].strip()
-            extended_queries[f'query{template_number}_part3'] = new_queries[2].strip()
+        queries = match[1].split(";")
+        if len(queries) == 1:
+            extended_queries[f'query{template_number}'] = queries[0].strip()
         else:
-            sql_query = match[1].strip()
-            extended_queries[f'query{template_number}'] = sql_query
+            for i in range(len(queries)):
+                extended_queries[f'query{template_number}_part{i+1}'] = queries[i].strip()
 
     return extended_queries
 

--- a/nds-h/nds_h_power.py
+++ b/nds-h/nds_h_power.py
@@ -77,7 +77,7 @@ def gen_sql_from_stream(query_stream_file_path):
     for match in matches:
         template_number = match[0]
         queries = match[1].split(";")
-        non_empty_queries = [q for q in queries if q.strip()]
+        non_empty_queries = [q.strip() for q in queries if q.strip()]
         if len(non_empty_queries) == 1:
             extended_queries[f'query{template_number}'] = non_empty_queries[0]
         else:

--- a/nds-h/nds_h_power.py
+++ b/nds-h/nds_h_power.py
@@ -77,11 +77,12 @@ def gen_sql_from_stream(query_stream_file_path):
     for match in matches:
         template_number = match[0]
         queries = match[1].split(";")
-        if len(queries) == 1:
-            extended_queries[f'query{template_number}'] = queries[0].strip()
+        non_empty_queries = [q for q in queries if q.strip()]
+        if len(non_empty_queries) == 1:
+            extended_queries[f'query{template_number}'] = non_empty_queries[0]
         else:
-            for i in range(len(queries)):
-                extended_queries[f'query{template_number}_part{i+1}'] = queries[i].strip()
+            for i in range(len(non_empty_queries)):
+                extended_queries[f'query{template_number}_part{i+1}'] = non_empty_queries[i]
 
     return extended_queries
 


### PR DESCRIPTION
```
-- Template file: 15

create temp view revenue1 (supplier_no, total_revenue) as ...;

select ...;

drop view revenue1;
```

The query parsing for NDS-H can support a test that runs multiple queries in it like the query 15 as seen above. The parsing currently has the query number 15 hard-coded in it for multi-query support. It skips the parsing otherwise. This hard-coded query number is unnecessary. The parsing also currently assumes that there are always 3 queries after parsing, which can be false. This PR generalizes the parsing logic to fix these problems.