### PR TITLE
Generalize the query parsing for the queries with multiple sub-queries for NDS

### DIFF
--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -106,7 +106,11 @@ def gen_sql_from_stream(query_stream_file_path):
         # e.g. "-- start query 32 in stream 0 using template query98.tpl"
         query_name = q[q.find('template')+9: q.find('.tpl')]
         queries = q.split(';')
-        non_empty_queries = [x.strip() for x in queries if x.strip()]
+        non_empty_queries = []
+        for q in queries:
+            q_stripped = q.strip()
+            if q_stripped and not q_stripped.startswith('--'):
+                non_empty_queries.append(q_stripped)
         if len(non_empty_queries) == 1:
             # normal query, just one query in the template
             extended_queries[query_name] = non_empty_queries[0]

--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -43,7 +43,6 @@ from PysparkBenchReport import PysparkBenchReport
 from pyspark.sql import DataFrame
 
 from check import check_json_summary_folder, check_query_subset_exists, check_version
-from nds_gen_query_stream import split_special_query
 from nds_schema import get_schemas
 
 check_version()
@@ -115,6 +114,9 @@ def gen_sql_from_stream(query_stream_file_path):
             # normal query, just one query in the template
             extended_queries[query_name] = non_empty_queries[0]
         else:
+            # Multiple sub-queries in the query.
+            # We want to update the template name for each part.
+            # See split_special_query function in nds_gen_query_stream.py for more details.
             head = queries[0].split('\n')[0]
             query_part = queries[0].replace('.tpl', '_part1.tpl') + ';'
             extended_queries[f'{query_name}_part1'] = query_part
@@ -125,12 +127,6 @@ def gen_sql_from_stream(query_stream_file_path):
                 query_part = head.replace('.tpl', f'_part{query_part_index}.tpl') + '\n'
                 query_part += non_empty_queries[index] + ';'
                 extended_queries[f'{query_name}_part{query_part_index}'] = query_part
-        # if 'select' in q.split(';')[1]:
-        #     part_1, part_2 = split_special_query(q)
-        #     extended_queries[query_name + '_part1'] = part_1
-        #     extended_queries[query_name + '_part2'] = part_2
-        # else:
-        #     extended_queries[query_name] = q
 
     # add "-- start" string back to each query
     for q_name, q_content in extended_queries.items():

--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -105,12 +105,28 @@ def gen_sql_from_stream(query_stream_file_path):
     for q in all_queries:
         # e.g. "-- start query 32 in stream 0 using template query98.tpl"
         query_name = q[q.find('template')+9: q.find('.tpl')]
-        if 'select' in q.split(';')[1]:
-            part_1, part_2 = split_special_query(q)
-            extended_queries[query_name + '_part1'] = part_1
-            extended_queries[query_name + '_part2'] = part_2
+        queries = q.split(';')
+        non_empty_queries = [x.strip() for x in queries if x.strip()]
+        if len(non_empty_queries) == 1:
+            # normal query, just one query in the template
+            extended_queries[query_name] = non_empty_queries[0]
         else:
-            extended_queries[query_name] = q
+            head = queries[0].split('\n')[0]
+            query_part = queries[0].replace('.tpl', '_part1.tpl') + ';'
+            extended_queries[f'{query_name}_part1'] = query_part
+            for i in range(len(non_empty_queries) - 1):
+                # We skip the first one since it's already added
+                index = i + 1
+                query_part_index = index + 1
+                query_part = head.replace('.tpl', f'_part{query_part_index}.tpl') + '\n'
+                query_part += non_empty_queries[index] + ';'
+                extended_queries[f'{query_name}_part{query_part_index}'] = query_part
+        # if 'select' in q.split(';')[1]:
+        #     part_1, part_2 = split_special_query(q)
+        #     extended_queries[query_name + '_part1'] = part_1
+        #     extended_queries[query_name + '_part2'] = part_2
+        # else:
+        #     extended_queries[query_name] = q
 
     # add "-- start" string back to each query
     for q_name, q_content in extended_queries.items():


### PR DESCRIPTION
Similar to https://github.com/NVIDIA/spark-rapids-benchmarks/pull/219, this PR generalizes the query parsing for the queries that have multiple sub-queries in it for NDS. This will allow us to run not only NDS queries, but also any queries with multiple sub-queries. The following is an example query for Delta update command that has 3 sub-queries. The first and the last sub-queries are for benchmark initialization and cleanup, respectively.

```
-- start query 2 in stream 0 using template update.tpl

CREATE TABLE store_sales_clone SHALLOW CLONE store_sales;

UPDATE store_sales_clone SET
    ss_wholesale_cost = ss_wholesale_cost * 2,
    ss_list_price = ss_list_price * 2,
    ss_sales_price = ss_sales_price * 2,
    ss_ext_sales_price = ss_ext_sales_price * 2,
    ss_ext_wholesale_cost = ss_ext_wholesale_cost * 2,
    ss_ext_list_price = ss_ext_list_price * 2,
    ss_ext_discount_amt = ss_ext_discount_amt * 2
WHERE ss_store_sk <= 20;

DROP TABLE store_sales_clone purge;

-- end query 2 in stream 0 using template update.tpl
```

The nds_power report will look like the below:

```
...
local-1761342354509,update_part1,2837
local-1761342354509,update_part2,27398
local-1761342354509,update_part3,474
...
```