### PR TITLE
Add support for setup/cleanup tags for NDS

### DIFF
--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -415,7 +415,7 @@ def run_query_stream(input_prefix,
     """
     queries_reports = []
     execution_time_list = []
-    total_time_start = time.time_ns()
+    total_time_start_ms = time.time_ns() // 1_000_000
     # check if it's running specific query or Power Run
     if len(query_dict) == 1:
         app_name = "NDS - " + list(query_dict.keys())[0]
@@ -457,9 +457,9 @@ def run_query_stream(input_prefix,
     profiler = Profiler(profiling_hook=profiling_hook, output_root=json_summary_folder)
 
     # Run query
-    power_start = time.time_ns()
-    setup_time = 0
-    cleanup_time = 0
+    power_start_ms = time.time_ns() // 1_000_000
+    setup_time_ms = 0
+    cleanup_time_ms = 0
     
     for query_name, q_content in query_dict.items():
         # show query name in Spark web UI
@@ -488,9 +488,9 @@ def run_query_stream(input_prefix,
             
             # Accumulate setup and cleanup times
             if query_type == 'setup':
-                setup_time += query_time
+                setup_time_ms += query_time
             elif query_type == 'cleanup':
-                cleanup_time += query_time
+                cleanup_time_ms += query_time
         
         queries_reports.append(q_report)
         if json_summary_folder:
@@ -505,36 +505,36 @@ def run_query_stream(input_prefix,
             else:
                 summary_prefix =  os.path.join(json_summary_folder, '')
             q_report.write_summary(prefix=summary_prefix)
-    power_end = time.time_ns()
-    power_elapse = int((power_end - power_start)/1000)
+    power_end_ms = time.time_ns() // 1_000_000
+    power_elapse_ms = power_end_ms - power_start_ms
 
     # Calculate Power Test Time (excluding setup and cleanup)
-    power_test_time = power_elapse - setup_time - cleanup_time
-    
+    power_test_time_ms = power_elapse_ms - setup_time_ms - cleanup_time_ms
+
     if not keep_sc:
         spark_session.sparkContext.stop()
-    total_time_end = time.time_ns()
-    total_elapse = int((total_time_end - total_time_start)/1000)
-    print("====== Power Test Time: {} milliseconds ======".format(power_test_time))
-    if setup_time > 0:
-        print("====== Power Setup Time: {} milliseconds ======".format(setup_time))
-    if cleanup_time > 0:
-        print("====== Power Cleanup Time: {} milliseconds ======".format(cleanup_time))
-    print("====== Total Time: {} milliseconds ======".format(total_elapse))
+    total_time_end_ms = time.time_ns() // 1_000_000
+    total_elapse_ms = total_time_end_ms - total_time_start_ms
+    print("====== Power Test Time: {} milliseconds ======".format(power_test_time_ms))
+    if setup_time_ms > 0:
+        print("====== Power Setup Time: {} milliseconds ======".format(setup_time_ms))
+    if cleanup_time_ms > 0:
+        print("====== Power Cleanup Time: {} milliseconds ======".format(cleanup_time_ms))
+    print("====== Total Time: {} milliseconds ======".format(total_elapse_ms))
     execution_time_list.append(
-        (spark_app_id, "Power Start Time", power_start))
+        (spark_app_id, "Power Start Time", power_start_ms))
     execution_time_list.append(
-        (spark_app_id, "Power End Time", power_end))
+        (spark_app_id, "Power End Time", power_end_ms))
     execution_time_list.append(
-        (spark_app_id, "Power Test Time", power_test_time))
-    if setup_time > 0:
+        (spark_app_id, "Power Test Time", power_test_time_ms))
+    if setup_time_ms > 0:
         execution_time_list.append(
-            (spark_app_id, "Power Setup Time", setup_time))
-    if cleanup_time > 0:
+            (spark_app_id, "Power Setup Time", setup_time_ms))
+    if cleanup_time_ms > 0:
         execution_time_list.append(
-            (spark_app_id, "Power Cleanup Time", cleanup_time))
+            (spark_app_id, "Power Cleanup Time", cleanup_time_ms))
     execution_time_list.append(
-        (spark_app_id, "Total Time", total_elapse))
+        (spark_app_id, "Total Time", total_elapse_ms))
 
     header = ["application_id", "query", "time/milliseconds"]
     # print to driver stdout for quick view

--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -130,7 +130,8 @@ def parse_query_content(query_content):
 
         if line_stripped == '-- start setup':
             if current_section != 'init':
-                raise RuntimeError("The setup section must be the first section if it exists.")
+                raise RuntimeError(f"Init expected, actual section {current_section}. "
+                                   f"The setup section must be the first section if it exists.")
             current_section = 'setup'
             continue
         elif line_stripped == '-- end setup':
@@ -140,7 +141,8 @@ def parse_query_content(query_content):
             continue
         elif line_stripped == '-- start cleanup':
             if current_section != 'benchmark':
-                raise RuntimeError("The cleanup section must come after the benchmark section.")
+                raise RuntimeError(f"benchmark expected, actual section {current_section}. "
+                                   f"The cleanup section must come after the benchmark section.")
             current_section = 'cleanup'
             continue
         elif line_stripped == '-- end cleanup':

--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -216,7 +216,8 @@ def gen_sql_from_stream(query_stream_file_path):
 
         parsed = parse_query_content(q)
 
-        def add_to_extended_queries(query_type, idx, parsed):
+        def add_to_extended_queries(query_type, i, parsed):
+            idx = i + 1
             subquery_cnt = len(parsed[query_type])
             if query_type == 'benchmark':
                 dict_key = f"{query_name}_part{idx}" if subquery_cnt > 1 else query_name
@@ -227,11 +228,11 @@ def gen_sql_from_stream(query_stream_file_path):
             extended_queries[dict_key] = query_part
 
         for i in range(len(parsed['setup'])):
-            add_to_extended_queries('setup', i + 1, parsed)
+            add_to_extended_queries('setup', i, parsed)
         for i in range(len(parsed['benchmark'])):
-            add_to_extended_queries('benchmark', i + 1, parsed)
+            add_to_extended_queries('benchmark', i, parsed)
         for i in range(len(parsed['cleanup'])):
-            add_to_extended_queries('cleanup', i + 1, parsed)
+            add_to_extended_queries('cleanup', i, parsed)
 
     # add "-- start" string back to each query
     for q_name, q_content in extended_queries.items():

--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -256,13 +256,13 @@ def setup_tables(spark_session, input_prefix, input_format, use_decimal, executi
     spark_app_id = spark_session.sparkContext.applicationId
     # Create TempView for tables
     for table_name in get_schemas(False).keys():
-        start = int(time.time() * 1000)
+        start = time.time_ns() // 1_000_000
         table_path = input_prefix + '/' + table_name
         reader =  spark_session.read.format(input_format)
         if input_format in ['csv', 'json']:
             reader = reader.schema(get_schemas(use_decimal)[table_name])
         reader.load(table_path).createOrReplaceTempView(table_name)
-        end = int(time.time() * 1000)
+        end = time.time_ns() // 1_000_000
         print("====== Creating TempView for table {} ======".format(table_name))
         print("Time taken: {} millis for table {}".format(end - start, table_name))
         execution_time_list.append(
@@ -273,12 +273,12 @@ def register_delta_tables(spark_session, input_prefix, execution_time_list):
     spark_app_id = spark_session.sparkContext.applicationId
     # Register tables for Delta Lake
     for table_name in get_schemas(False).keys():
-        start = int(time.time() * 1000)
+        start = time.time_ns() // 1_000_000
         # input_prefix must be absolute path: https://github.com/delta-io/delta/issues/555
         register_sql = f"CREATE TABLE IF NOT EXISTS {table_name} USING DELTA LOCATION '{input_prefix}/{table_name}'"
         print(register_sql)
         spark_session.sql(register_sql)
-        end = int(time.time() * 1000)
+        end = time.time_ns() // 1_000_000
         print("====== Registering for table {} ======".format(table_name))
         print("Time taken: {} millis for table {}".format(end - start, table_name))
         execution_time_list.append(
@@ -415,7 +415,7 @@ def run_query_stream(input_prefix,
     """
     queries_reports = []
     execution_time_list = []
-    total_time_start = time.time()
+    total_time_start = time.time_ns()
     # check if it's running specific query or Power Run
     if len(query_dict) == 1:
         app_name = "NDS - " + list(query_dict.keys())[0]
@@ -457,7 +457,7 @@ def run_query_stream(input_prefix,
     profiler = Profiler(profiling_hook=profiling_hook, output_root=json_summary_folder)
 
     # Run query
-    power_start = int(time.time())
+    power_start = time.time_ns()
     setup_time = 0
     cleanup_time = 0
     
@@ -505,16 +505,16 @@ def run_query_stream(input_prefix,
             else:
                 summary_prefix =  os.path.join(json_summary_folder, '')
             q_report.write_summary(prefix=summary_prefix)
-    power_end = int(time.time())
-    power_elapse = int((power_end - power_start)*1000)
-    
+    power_end = time.time_ns()
+    power_elapse = int((power_end - power_start)/1000)
+
     # Calculate Power Test Time (excluding setup and cleanup)
     power_test_time = power_elapse - setup_time - cleanup_time
     
     if not keep_sc:
         spark_session.sparkContext.stop()
-    total_time_end = time.time()
-    total_elapse = int((total_time_end - total_time_start)*1000)
+    total_time_end = time.time_ns()
+    total_elapse = int((total_time_end - total_time_start)/1000)
     print("====== Power Test Time: {} milliseconds ======".format(power_test_time))
     if setup_time > 0:
         print("====== Power Setup Time: {} milliseconds ======".format(setup_time))

--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -629,7 +629,8 @@ if __name__ == "__main__":
                         help='comma separated list of queries to run. If not specified, all queries ' +
                         'in the stream file will be run. e.g. "query1,query2,query3". Note, use ' +
                         '"_part1" and "_part2" suffix for the following query names: ' +
-                        'query14, query23, query24, query39. e.g. query14_part1, query39_part2')
+                        'query14, query23, query24, query39. e.g. query14_part1, query39_part2. '
+                        'Regex patterns are also supported to select multiple queries. e.g. "query1,query2,query14*"')
     parser.add_argument('--allow_failure',
                         action='store_true',
                         help='Do not exit with non zero when any query failed or any task failed')

--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -47,6 +47,7 @@ from nds_schema import get_schemas
 
 check_version()
 
+
 class Profiler:
     def __init__(self, profiling_hook, output_root):
         self.profiling_hook = profiling_hook
@@ -87,6 +88,98 @@ class Profiler:
             print("Profiling stopped")
 
 
+def split_and_strip(str, delimiter):
+    return [s.strip() for s in str.split(delimiter) if s.strip()]
+
+
+def parse_query_content(query_content):
+    """
+    Parse query content to identify setup, benchmark, and cleanup sections.
+    
+    Args:
+        query_content (str): The full query content potentially containing timing tags.
+        
+    Returns:
+        dict: A dictionary with keys:
+            - 'setup': SQL string before '-- start benchmark'
+            - 'benchmark': SQL string between '-- start benchmark' and '-- end benchmark'
+            - 'cleanup': SQL string after '-- end benchmark'
+    """
+    lines = split_and_strip(query_content, '\n')
+    head = lines[0]
+    lines = lines[1:]  # Exclude the head line
+    
+    setup_lines = []
+    benchmark_lines = []
+    cleanup_lines = []
+    
+    current_section = 'setup'  # Start in setup section
+    has_tags = False
+    
+    for line in lines:
+        line_stripped = line.strip()
+        if not line_stripped:
+            continue
+        if line_stripped.startswith('-- end query'):
+            break
+
+        if line_stripped == '-- start benchmark':
+            has_tags = True
+            current_section = 'benchmark'
+            continue
+        elif line_stripped == '-- end benchmark':
+            has_tags = True
+            current_section = 'cleanup'
+            continue
+        
+        if current_section == 'setup':
+            setup_lines.append(line)
+        elif current_section == 'benchmark':
+            print(f"Adding to benchmark: {line}")
+            benchmark_lines.append(line)
+        elif current_section == 'cleanup':
+            cleanup_lines.append(line)
+    
+    # Convert lists to strings
+    setup_sql = '\n'.join(setup_lines).strip()
+    benchmark_sql = '\n'.join(benchmark_lines).strip()
+    cleanup_sql = '\n'.join(cleanup_lines).strip()
+    
+    # If no tags found, all content is benchmark
+    if not has_tags:
+        return {
+            'query_tpl': head,
+            'setup': [],
+            'benchmark': split_and_strip('\n'.join(lines), ';')[:-1],
+            'cleanup': []
+        }
+    
+    return {
+        'query_tpl': head,
+        'setup': split_and_strip(setup_sql, ';'),
+        'benchmark': split_and_strip(benchmark_sql, ';'),
+        'cleanup': split_and_strip(cleanup_sql, ';')
+    }
+
+
+def get_query_type(query_name):
+    """
+    Determine the query type based on its name suffix.
+    
+    Args:
+        query_name (str): The name of the query.
+        
+    Returns:
+        str: One of 'setup', 'cleanup', or 'benchmark'
+    """
+    if query_name.endswith('_setup') or '_setup_' in query_name:
+        return 'setup'
+    elif query_name.endswith('_cleanup') or '_cleanup_' in query_name:
+        return 'cleanup'
+    else:
+        return 'benchmark'
+
+
 def gen_sql_from_stream(query_stream_file_path):
     """Read Spark compatible query stream and split them one by one
 
@@ -98,39 +191,38 @@ def gen_sql_from_stream(query_stream_file_path):
     """
     with open(query_stream_file_path, 'r') as f:
         stream = f.read()
-    all_queries = stream.split('-- start')[1:]
+    all_queries = stream.split('-- start query')[1:]
     # split query in query14, query23, query24, query39
     extended_queries = OrderedDict()
     for q in all_queries:
         # e.g. "-- start query 32 in stream 0 using template query98.tpl"
         query_name = q[q.find('template')+9: q.find('.tpl')]
-        queries = q.split(';')
-        non_empty_queries = []
-        for q in queries:
-            q_stripped = q.strip()
-            if q_stripped and not q_stripped.startswith('--'):
-                non_empty_queries.append(q_stripped)
-        if len(non_empty_queries) == 1:
-            # normal query, just one query in the template
-            extended_queries[query_name] = non_empty_queries[0]
-        else:
-            # Multiple sub-queries in the query.
-            # We want to update the template name for each part.
-            # See split_special_query function in nds_gen_query_stream.py for more details.
-            head = queries[0].split('\n')[0]
-            query_part = queries[0].replace('.tpl', '_part1.tpl') + ';'
-            extended_queries[f'{query_name}_part1'] = query_part
-            for i in range(len(non_empty_queries) - 1):
-                # We skip the first one since it's already added
-                index = i + 1
-                query_part_index = index + 1
-                query_part = head.replace('.tpl', f'_part{query_part_index}.tpl') + '\n'
-                query_part += non_empty_queries[index] + ';'
-                extended_queries[f'{query_name}_part{query_part_index}'] = query_part
+
+        parsed = parse_query_content(q)
+
+        for i in range(len(parsed['setup'])):
+            setup_idx = i + 1
+            setup_query_name = f"{query_name}_setup_{setup_idx}"
+            query_part = parsed['query_tpl'].replace('.tpl', f'_setup_{setup_idx}.tpl') + '\n'
+            query_part += parsed['setup'][i] + ';'
+            extended_queries[setup_query_name] = query_part
+        for i in range(len(parsed['benchmark'])):
+            benchmark_idx = i + 1
+            benchmark_query_name = f"{query_name}_part{benchmark_idx}" if len(parsed['benchmark']) > 1 else query_name
+            query_part = parsed['query_tpl'].replace('.tpl', f'_part{benchmark_idx}.tpl') + '\n'
+            query_part += parsed['benchmark'][i] + ';'
+            extended_queries[benchmark_query_name] = query_part
+        for i in range(len(parsed['cleanup'])):
+            cleanup_idx = i + 1
+            cleanup_query_name = f"{query_name}_cleanup_{cleanup_idx}"
+            query_part = parsed['query_tpl'].replace('.tpl', f'_cleanup_{cleanup_idx}.tpl') + '\n'
+            query_part += parsed['cleanup'][i] + ';'
+            extended_queries[cleanup_query_name] = query_part
 
     # add "-- start" string back to each query
     for q_name, q_content in extended_queries.items():
-        extended_queries[q_name] = '-- start' + q_content
+        extended_queries[q_name] = '-- start query' + q_content
+
     return extended_queries
 
 def setup_tables(spark_session, input_prefix, input_format, use_decimal, execution_time_list):
@@ -345,11 +437,18 @@ def run_query_stream(input_prefix,
 
     # Run query
     power_start = int(time.time())
+    setup_time = 0
+    cleanup_time = 0
+    
     for query_name, q_content in query_dict.items():
         # show query name in Spark web UI
         spark_session.sparkContext.setJobGroup(query_name, query_name)
         print("====== Run {} ======".format(query_name))
         q_report = PysparkBenchReport(spark_session, query_name)
+        
+        # Determine query type
+        query_type = get_query_type(query_name)
+        
         summary = q_report.report_on(run_one_query,warmup_iterations,
                                                    iterations,
                                                    spark_session,
@@ -365,8 +464,19 @@ def run_query_stream(input_prefix,
         query_times = summary['queryTimes']
         for query_time in query_times:
             execution_time_list.append((spark_app_id, query_name, query_time))
+            
+            # Accumulate setup and cleanup times
+            if query_type == 'setup':
+                setup_time += query_time
+            elif query_type == 'cleanup':
+                cleanup_time += query_time
+        
         queries_reports.append(q_report)
         if json_summary_folder:
+            # Add query type and includeInTotal to the summary
+            q_report.summary['queryType'] = query_type
+            q_report.summary['includeInTotal'] = (query_type == 'benchmark')
+            
             # property_file e.g.: "property/aqe-on.properties" or just "aqe-off.properties"
             if property_file:
                 summary_prefix = os.path.join(
@@ -376,18 +486,32 @@ def run_query_stream(input_prefix,
             q_report.write_summary(prefix=summary_prefix)
     power_end = int(time.time())
     power_elapse = int((power_end - power_start)*1000)
+    
+    # Calculate Power Test Time (excluding setup and cleanup)
+    power_test_time = power_elapse - setup_time - cleanup_time
+    
     if not keep_sc:
         spark_session.sparkContext.stop()
     total_time_end = time.time()
     total_elapse = int((total_time_end - total_time_start)*1000)
-    print("====== Power Test Time: {} milliseconds ======".format(power_elapse))
+    print("====== Power Test Time: {} milliseconds ======".format(power_test_time))
+    if setup_time > 0:
+        print("====== Power Setup Time: {} milliseconds ======".format(setup_time))
+    if cleanup_time > 0:
+        print("====== Power Cleanup Time: {} milliseconds ======".format(cleanup_time))
     print("====== Total Time: {} milliseconds ======".format(total_elapse))
     execution_time_list.append(
         (spark_app_id, "Power Start Time", power_start))
     execution_time_list.append(
         (spark_app_id, "Power End Time", power_end))
     execution_time_list.append(
-        (spark_app_id, "Power Test Time", power_elapse))
+        (spark_app_id, "Power Test Time", power_test_time))
+    if setup_time > 0:
+        execution_time_list.append(
+            (spark_app_id, "Power Setup Time", setup_time))
+    if cleanup_time > 0:
+        execution_time_list.append(
+            (spark_app_id, "Power Cleanup Time", cleanup_time))
     execution_time_list.append(
         (spark_app_id, "Total Time", total_elapse))
 

--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -256,13 +256,13 @@ def setup_tables(spark_session, input_prefix, input_format, use_decimal, executi
     spark_app_id = spark_session.sparkContext.applicationId
     # Create TempView for tables
     for table_name in get_schemas(False).keys():
-        start = time.time_ns() // 1_000_000
+        start = int(time.time() * 1000)
         table_path = input_prefix + '/' + table_name
         reader =  spark_session.read.format(input_format)
         if input_format in ['csv', 'json']:
             reader = reader.schema(get_schemas(use_decimal)[table_name])
         reader.load(table_path).createOrReplaceTempView(table_name)
-        end = time.time_ns() // 1_000_000
+        end = int(time.time() * 1000)
         print("====== Creating TempView for table {} ======".format(table_name))
         print("Time taken: {} millis for table {}".format(end - start, table_name))
         execution_time_list.append(
@@ -273,12 +273,12 @@ def register_delta_tables(spark_session, input_prefix, execution_time_list):
     spark_app_id = spark_session.sparkContext.applicationId
     # Register tables for Delta Lake
     for table_name in get_schemas(False).keys():
-        start = time.time_ns() // 1_000_000
+        start = int(time.time() * 1000)
         # input_prefix must be absolute path: https://github.com/delta-io/delta/issues/555
         register_sql = f"CREATE TABLE IF NOT EXISTS {table_name} USING DELTA LOCATION '{input_prefix}/{table_name}'"
         print(register_sql)
         spark_session.sql(register_sql)
-        end = time.time_ns() // 1_000_000
+        end = int(time.time() * 1000)
         print("====== Registering for table {} ======".format(table_name))
         print("Time taken: {} millis for table {}".format(end - start, table_name))
         execution_time_list.append(
@@ -415,7 +415,7 @@ def run_query_stream(input_prefix,
     """
     queries_reports = []
     execution_time_list = []
-    total_time_start = time.time_ns()
+    total_time_start = time.time()
     # check if it's running specific query or Power Run
     if len(query_dict) == 1:
         app_name = "NDS - " + list(query_dict.keys())[0]
@@ -457,7 +457,7 @@ def run_query_stream(input_prefix,
     profiler = Profiler(profiling_hook=profiling_hook, output_root=json_summary_folder)
 
     # Run query
-    power_start = time.time_ns()
+    power_start = int(time.time())
     setup_time = 0
     cleanup_time = 0
     
@@ -505,16 +505,16 @@ def run_query_stream(input_prefix,
             else:
                 summary_prefix =  os.path.join(json_summary_folder, '')
             q_report.write_summary(prefix=summary_prefix)
-    power_end = time.time_ns()
-    power_elapse = int((power_end - power_start)/1000)
-
+    power_end = int(time.time())
+    power_elapse = int((power_end - power_start)*1000)
+    
     # Calculate Power Test Time (excluding setup and cleanup)
     power_test_time = power_elapse - setup_time - cleanup_time
     
     if not keep_sc:
         spark_session.sparkContext.stop()
-    total_time_end = time.time_ns()
-    total_elapse = int((total_time_end - total_time_start)/1000)
+    total_time_end = time.time()
+    total_elapse = int((total_time_end - total_time_start)*1000)
     print("====== Power Test Time: {} milliseconds ======".format(power_test_time))
     if setup_time > 0:
         print("====== Power Setup Time: {} milliseconds ======".format(setup_time))

--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -102,6 +102,7 @@ def parse_query_content(query_content):
         
     Returns:
         dict: A dictionary with keys:
+            - 'query_tpl': Query name template. This will be updated based on the query type and index.
             - 'setup': SQL string before '-- start benchmark'
             - 'benchmark': SQL string between '-- start benchmark' and '-- end benchmark'
             - 'cleanup': SQL string after '-- end benchmark'
@@ -185,9 +186,9 @@ def get_query_type(query_name):
     Returns:
         str: One of 'setup', 'cleanup', or 'benchmark'
     """
-    if query_name.endswith('_setup') or '_setup_' in query_name:
+    if '_setup' in query_name:
         return 'setup'
-    elif query_name.endswith('_cleanup') or '_cleanup_' in query_name:
+    elif '_cleanup' in query_name:
         return 'cleanup'
     else:
         return 'benchmark'
@@ -213,24 +214,22 @@ def gen_sql_from_stream(query_stream_file_path):
 
         parsed = parse_query_content(q)
 
+        def add_to_extended_queries(query_type, idx, parsed):
+            subquery_cnt = len(parsed[query_type])
+            if query_type == 'benchmark':
+                dict_key = f"{query_name}_part{idx}" if subquery_cnt > 1 else query_name
+            else:
+                dict_key = f"{query_name}_{query_type}{idx}" if subquery_cnt > 1 else f"{query_name}_{query_type}"
+            query_part = parsed['query_tpl'].replace('.tpl', f'_{query_type}{idx}.tpl') + '\n'
+            query_part += parsed[query_type][i] + ';'
+            extended_queries[dict_key] = query_part
+
         for i in range(len(parsed['setup'])):
-            setup_idx = i + 1
-            setup_query_name = f"{query_name}_setup_{setup_idx}"
-            query_part = parsed['query_tpl'].replace('.tpl', f'_setup_{setup_idx}.tpl') + '\n'
-            query_part += parsed['setup'][i] + ';'
-            extended_queries[setup_query_name] = query_part
+            add_to_extended_queries('setup', i + 1, parsed)
         for i in range(len(parsed['benchmark'])):
-            benchmark_idx = i + 1
-            benchmark_query_name = f"{query_name}_part{benchmark_idx}" if len(parsed['benchmark']) > 1 else query_name
-            query_part = parsed['query_tpl'].replace('.tpl', f'_part{benchmark_idx}.tpl') + '\n'
-            query_part += parsed['benchmark'][i] + ';'
-            extended_queries[benchmark_query_name] = query_part
+            add_to_extended_queries('benchmark', i + 1, parsed)
         for i in range(len(parsed['cleanup'])):
-            cleanup_idx = i + 1
-            cleanup_query_name = f"{query_name}_cleanup_{cleanup_idx}"
-            query_part = parsed['query_tpl'].replace('.tpl', f'_cleanup_{cleanup_idx}.tpl') + '\n'
-            query_part += parsed['cleanup'][i] + ';'
-            extended_queries[cleanup_query_name] = query_part
+            add_to_extended_queries('cleanup', i + 1, parsed)
 
     # add "-- start" string back to each query
     for q_name, q_content in extended_queries.items():
@@ -363,12 +362,8 @@ def ensure_valid_column_names(df: DataFrame):
 
 def get_query_subset(query_dict, subset):
     """Get a subset of queries from query_dict.
-    The subset is specified by a list of query names.
+    The subset is specified by a list of regex patterns for the query name.
     """
-    # check_query_subset_exists(query_dict, subset)
-    # return dict((k, query_dict[k]) for k in subset)
-
-    # subset is a list of regex for query names.
     selected_queries = OrderedDict()
     for pattern in subset:
         for query_name in query_dict.keys():

--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -33,6 +33,7 @@
 import argparse
 import csv
 import os
+import re
 import sys
 import time
 import subprocess 
@@ -352,9 +353,19 @@ def get_query_subset(query_dict, subset):
     """Get a subset of queries from query_dict.
     The subset is specified by a list of query names.
     """
-    check_query_subset_exists(query_dict, subset)
-    return dict((k, query_dict[k]) for k in subset)
+    # check_query_subset_exists(query_dict, subset)
+    # return dict((k, query_dict[k]) for k in subset)
 
+    # subset is a list of regex for query names.
+    selected_queries = OrderedDict()
+    for pattern in subset:
+        for query_name in query_dict.keys():
+            if re.match(pattern, query_name):
+                selected_queries[query_name] = query_dict[query_name]
+    if not selected_queries:
+        msg = f"No query matched the specified subset patterns: {subset}"
+        raise Exception(msg)
+    return selected_queries
 
 def run_query_stream(input_prefix,
                      property_file,

--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -415,7 +415,7 @@ def run_query_stream(input_prefix,
     """
     queries_reports = []
     execution_time_list = []
-    total_time_start_ms = time.time_ns() // 1_000_000
+    total_time_start = time.time_ns()
     # check if it's running specific query or Power Run
     if len(query_dict) == 1:
         app_name = "NDS - " + list(query_dict.keys())[0]
@@ -457,9 +457,9 @@ def run_query_stream(input_prefix,
     profiler = Profiler(profiling_hook=profiling_hook, output_root=json_summary_folder)
 
     # Run query
-    power_start_ms = time.time_ns() // 1_000_000
-    setup_time_ms = 0
-    cleanup_time_ms = 0
+    power_start = time.time_ns()
+    setup_time = 0
+    cleanup_time = 0
     
     for query_name, q_content in query_dict.items():
         # show query name in Spark web UI
@@ -488,9 +488,9 @@ def run_query_stream(input_prefix,
             
             # Accumulate setup and cleanup times
             if query_type == 'setup':
-                setup_time_ms += query_time
+                setup_time += query_time
             elif query_type == 'cleanup':
-                cleanup_time_ms += query_time
+                cleanup_time += query_time
         
         queries_reports.append(q_report)
         if json_summary_folder:
@@ -505,36 +505,36 @@ def run_query_stream(input_prefix,
             else:
                 summary_prefix =  os.path.join(json_summary_folder, '')
             q_report.write_summary(prefix=summary_prefix)
-    power_end_ms = time.time_ns() // 1_000_000
-    power_elapse_ms = power_end_ms - power_start_ms
+    power_end = time.time_ns()
+    power_elapse = int((power_end - power_start)/1000)
 
     # Calculate Power Test Time (excluding setup and cleanup)
-    power_test_time_ms = power_elapse_ms - setup_time_ms - cleanup_time_ms
-
+    power_test_time = power_elapse - setup_time - cleanup_time
+    
     if not keep_sc:
         spark_session.sparkContext.stop()
-    total_time_end_ms = time.time_ns() // 1_000_000
-    total_elapse_ms = total_time_end_ms - total_time_start_ms
-    print("====== Power Test Time: {} milliseconds ======".format(power_test_time_ms))
-    if setup_time_ms > 0:
-        print("====== Power Setup Time: {} milliseconds ======".format(setup_time_ms))
-    if cleanup_time_ms > 0:
-        print("====== Power Cleanup Time: {} milliseconds ======".format(cleanup_time_ms))
-    print("====== Total Time: {} milliseconds ======".format(total_elapse_ms))
+    total_time_end = time.time_ns()
+    total_elapse = int((total_time_end - total_time_start)/1000)
+    print("====== Power Test Time: {} milliseconds ======".format(power_test_time))
+    if setup_time > 0:
+        print("====== Power Setup Time: {} milliseconds ======".format(setup_time))
+    if cleanup_time > 0:
+        print("====== Power Cleanup Time: {} milliseconds ======".format(cleanup_time))
+    print("====== Total Time: {} milliseconds ======".format(total_elapse))
     execution_time_list.append(
-        (spark_app_id, "Power Start Time", power_start_ms))
+        (spark_app_id, "Power Start Time", power_start))
     execution_time_list.append(
-        (spark_app_id, "Power End Time", power_end_ms))
+        (spark_app_id, "Power End Time", power_end))
     execution_time_list.append(
-        (spark_app_id, "Power Test Time", power_test_time_ms))
-    if setup_time_ms > 0:
+        (spark_app_id, "Power Test Time", power_test_time))
+    if setup_time > 0:
         execution_time_list.append(
-            (spark_app_id, "Power Setup Time", setup_time_ms))
-    if cleanup_time_ms > 0:
+            (spark_app_id, "Power Setup Time", setup_time))
+    if cleanup_time > 0:
         execution_time_list.append(
-            (spark_app_id, "Power Cleanup Time", cleanup_time_ms))
+            (spark_app_id, "Power Cleanup Time", cleanup_time))
     execution_time_list.append(
-        (spark_app_id, "Total Time", total_elapse_ms))
+        (spark_app_id, "Total Time", total_elapse))
 
     header = ["application_id", "query", "time/milliseconds"]
     # print to driver stdout for quick view

--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -114,8 +114,7 @@ def parse_query_content(query_content):
     benchmark_lines = []
     cleanup_lines = []
     
-    current_section = 'setup'  # Start in setup section
-    has_tags = False
+    current_section = 'init'
     
     for line in lines:
         line_stripped = line.strip()
@@ -124,36 +123,49 @@ def parse_query_content(query_content):
         if line_stripped.startswith('-- end query'):
             break
 
-        if line_stripped == '-- start benchmark':
-            has_tags = True
+        # Transitions allowed:
+        # init -> (setup) -> benchmark -> (cleanup -> done)
+        # All other transitions are invalid.
+
+        if line_stripped == '-- start setup':
+            if current_section != 'init':
+                raise RuntimeError("The setup section must be the first section if it exists.")
+            current_section = 'setup'
+            continue
+        elif line_stripped == '-- end setup':
+            if current_section != 'setup':
+                raise RuntimeError("Mismatched end setup tag.")
             current_section = 'benchmark'
             continue
-        elif line_stripped == '-- end benchmark':
-            has_tags = True
+        elif line_stripped == '-- start cleanup':
+            if current_section != 'benchmark':
+                raise RuntimeError("The cleanup section must come after the benchmark section.")
             current_section = 'cleanup'
             continue
-        
+        elif line_stripped == '-- end cleanup':
+            if current_section != 'cleanup':
+                raise RuntimeError("Mismatched end cleanup tag.")
+            current_section = 'done'
+            continue
+
+        if current_section == 'init':
+            # No tag has been found yet, so assume this is the benchmark section
+            current_section = 'benchmark'
+
         if current_section == 'setup':
             setup_lines.append(line)
         elif current_section == 'benchmark':
-            print(f"Adding to benchmark: {line}")
             benchmark_lines.append(line)
         elif current_section == 'cleanup':
             cleanup_lines.append(line)
     
+    if current_section != 'benchmark' and current_section != 'done':
+        raise RuntimeError("Unclosed section detected in query content. Current section: " + current_section)
+
     # Convert lists to strings
     setup_sql = '\n'.join(setup_lines).strip()
     benchmark_sql = '\n'.join(benchmark_lines).strip()
     cleanup_sql = '\n'.join(cleanup_lines).strip()
-    
-    # If no tags found, all content is benchmark
-    if not has_tags:
-        return {
-            'query_tpl': head,
-            'setup': [],
-            'benchmark': split_and_strip('\n'.join(lines), ';')[:-1],
-            'cleanup': []
-        }
     
     return {
         'query_tpl': head,


### PR DESCRIPTION
Fixes #224.

This PR adds support for the new tags for per-query setup and cleanup. These new tags will be useful for table format benchmarks such as Delta and Iceberg. The nds_power script will measure the queries tagged and report their timings, but their timings won't be counted for the `Power Test Time`. Here is an example.

```sql
-- start query 4 in stream 0 using template merge.tpl

-- start setup

CREATE TABLE store_sales_clone SHALLOW CLONE store_sales;

-- end setup

MERGE INTO store_sales_clone AS target ... ;

-- start cleanup

DROP TABLE store_sales_clone purge;

-- end cleanup

-- end query 4 in stream 0 using template merge.tpl
```

Note that the setup and cleanup tags are optional.

The CSV report file. The Power Setup Time and Power Cleanup Time will be included only when the setup and cleanup queries exist.

```
...
local-1761777398798,merge_setup,9304
local-1761777398798,merge,53187
local-1761777398798,merge_cleanup,3654
local-1761777398798,Power Start Time,1761777407
local-1761777398798,Power End Time,1761777473
local-1761777398798,Power Test Time,53042
local-1761777398798,Power Setup Time,9304
local-1761777398798,Power Cleanup Time,3654
local-1761777398798,Total Time,77920
```

The JSON query report files. `queryType` and `includeInTotal` are new fields.

```json
...
  "queryTimes": [
    9304
  ],
  "query": "merge_setup",
  "queryType": "setup",
  "includeInTotal": false,
...
```

```json
...
  "queryTimes": [
    53187
  ],
  "query": "merge",
  "queryType": "benchmark",
  "includeInTotal": true,
...
```

```json
...
  "queryTimes": [
    3654
  ],
  "query": "merge_cleanup",
  "queryType": "cleanup",
  "includeInTotal": false,
...
```

Besides the new tag support, this PR also improves the query name filter for the benchmark. It currently supports only the exact name filter, but it will support the regex pattern after this PR. This will be useful to run all SQLs for one query. For example, you can use `--sub_queries merge*` instead of `--sub_queries merge_setup, merge, merge_cleanup`.