### PR TITLE
Fix listener unregister issue

### DIFF
--- a/nds/PysparkBenchReport.py
+++ b/nds/PysparkBenchReport.py
@@ -76,6 +76,7 @@ class PysparkBenchReport:
             listener.register()
         except TypeError as e:
             print("Not found com.nvidia.spark.rapids.listener.Manager", str(e))
+            listener = None
         return listener
 
     def _get_spark_conf(self):


### PR DESCRIPTION
It's a regression issue. The Python listener should be set to None when it fails to register.

To fix https://github.com/NVIDIA/spark-rapids-benchmarks/issues/229