### PR TITLE
Update to use delta lake 2.1.1 for Spark 3.3.0

### DIFF
--- a/nds/convert_submit_cpu_delta.template
+++ b/nds/convert_submit_cpu_delta.template
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-# 1. The io.delta:delta-core_2.12:1.1.0 only works on Spark 3.2.x
+# 1. The io.delta:delta-core_2.12:2.1.1 only works on Spark 3.3.x
 #    Please refer to https://docs.delta.io/latest/releases.html for other Spark versions.
 
 source base.template
@@ -28,6 +28,6 @@ export SPARK_CONF=("--master" "${SPARK_MASTER}"
                    "--conf" "spark.executor.instances=${NUM_EXECUTORS}"
                    "--conf" "spark.executor.memory=${EXECUTOR_MEMORY}"
                    "--conf" "spark.sql.shuffle.partitions=${SHUFFLE_PARTITIONS}"
-                   "--packages" "io.delta:delta-core_2.12:1.1.0"
+                   "--packages" "io.delta:delta-core_2.12:2.1.1"
                    "--conf" "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension"
                    "--conf" "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog")

--- a/nds/convert_submit_cpu_delta.template
+++ b/nds/convert_submit_cpu_delta.template
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/nds/maintenance_delta.template
+++ b/nds/maintenance_delta.template
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-# 1. The io.delta:delta-core_2.12:1.1.0 only works on Spark 3.2.x
+# 1. The io.delta:delta-core_2.12:2.1.1 only works on Spark 3.3.x
 #    Please refer to https://docs.delta.io/latest/releases.html for other Spark versions.
 
 source base.template
@@ -29,7 +29,7 @@ export SPARK_CONF=("--master" "${SPARK_MASTER}"
                    "--conf" "spark.executor.instances=${NUM_EXECUTORS}"
                    "--conf" "spark.executor.memory=${EXECUTOR_MEMORY}"
                    "--conf" "spark.sql.shuffle.partitions=${SHUFFLE_PARTITIONS}"
-                   "--packages" "io.delta:delta-core_2.12:1.1.0"
+                   "--packages" "io.delta:delta-core_2.12:2.1.1"
                    "--conf" "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension"
                    "--conf" "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog"
                    "--jars" "$NDS_LISTENER_JAR")

--- a/nds/maintenance_delta.template
+++ b/nds/maintenance_delta.template
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/nds/power_run_cpu_delta.template
+++ b/nds/power_run_cpu_delta.template
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-# 1. The io.delta:delta-core_2.12:1.1.0 only works on Spark 3.2.x
+# 1. The io.delta:delta-core_2.12:2.1.1 only works on Spark 3.3.x
 #    Please refer to https://docs.delta.io/latest/releases.html for other Spark versions.
 
 source base.template
@@ -28,7 +28,7 @@ export SPARK_CONF=("--master" "${SPARK_MASTER}"
                    "--conf" "spark.executor.instances=${NUM_EXECUTORS}"
                    "--conf" "spark.executor.memory=${EXECUTOR_MEMORY}"
                    "--conf" "spark.sql.shuffle.partitions=${SHUFFLE_PARTITIONS}"
-                   "--packages" "io.delta:delta-core_2.12:1.1.0"
+                   "--packages" "io.delta:delta-core_2.12:2.1.1"
                    "--conf" "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension"
                    "--conf" "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog"
                    "--jars" "$NDS_LISTENER_JAR")

--- a/nds/power_run_cpu_delta.template
+++ b/nds/power_run_cpu_delta.template
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/nds/power_run_gpu_delta.template
+++ b/nds/power_run_gpu_delta.template
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-# 1. The io.delta:delta-core_2.12:1.1.0 only works on Spark 3.2.x
+# 1. The io.delta:delta-core_2.12:2.1.1 only works on Spark 3.3.x
 #    Please refer to https://docs.delta.io/latest/releases.html for other Spark versions.
 
 source base.template
@@ -39,7 +39,7 @@ export SPARK_CONF=("--master" "${SPARK_MASTER}"
                    "--conf" "spark.rapids.memory.host.spillStorageSize=32G"
                    "--conf" "spark.rapids.memory.pinnedPool.size=8g"
                    "--conf" "spark.rapids.sql.concurrentGpuTasks=${CONCURRENT_GPU_TASKS}"
-                   "--packages" "io.delta:delta-core_2.12:1.1.0"
+                   "--packages" "io.delta:delta-core_2.12:2.1.1"
                    "--conf" "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension"
                    "--conf" "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog"
                    "--files" "$SPARK_HOME/examples/src/main/scripts/getGpusResources.sh"

--- a/nds/power_run_gpu_delta.template
+++ b/nds/power_run_gpu_delta.template
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
To fix https://github.com/NVIDIA/spark-rapids-benchmarks/issues/237

As per the doc (https://docs.nvidia.com/spark-rapids/user-guide/25.10/additional-functionality/delta-lake-support.html), update to use delta lake 2.1.1 for Spark 3.3.0.

Verified this change in build NDS-automation/1029