### PR TITLE
Fix issue where query name disappeared from SQL tab in UI

### DIFF
--- a/nds-h/nds_h_power.py
+++ b/nds-h/nds_h_power.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/nds-h/nds_h_power.py
+++ b/nds-h/nds_h_power.py
@@ -40,12 +40,13 @@ import sys
 import re
 import subprocess
 
-parent_dir = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), '..'))
-
-# Construct the path to the utils directory
+# Python doesn't automatically include sibling directories in the import path.
+# We need to explicitly add the utils directory to sys.path to import shared utilities.
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 utils_dir = os.path.join(parent_dir, 'utils')
-# Add the utils directory to sys.path
-sys.path.insert(0, utils_dir)
+if utils_dir not in sys.path:
+    sys.path.insert(0, utils_dir)
+from spark_utils import setQueryName, clearQueryName
 
 from python_benchmark_reporter.PysparkBenchReport import PysparkBenchReport
 from pyspark.sql import DataFrame
@@ -281,7 +282,7 @@ def run_query_stream(input_prefix,
     power_start = int(time.time())
     for query_name, q_content in query_dict.items():
         # show query name in Spark web UI
-        spark_session.sparkContext.setJobGroup(query_name, query_name)
+        setQueryName(spark_session, query_name)
         print("====== Run {} ======".format(query_name))
         q_report = PysparkBenchReport(spark_session, query_name)
         summary = q_report.report_on(run_one_query,
@@ -307,6 +308,7 @@ def run_query_stream(input_prefix,
             else:
                 summary_prefix = os.path.join(json_summary_folder, '')
             q_report.write_summary(prefix=summary_prefix)
+    clearQueryName(spark_session)
     power_end = int(time.time())
     power_elapse = int((power_end - power_start)*1000)
     if not keep_sc:

--- a/nds/nds_maintenance.py
+++ b/nds/nds_maintenance.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/nds/nds_maintenance.py
+++ b/nds/nds_maintenance.py
@@ -34,6 +34,7 @@ import argparse
 import csv
 from datetime import datetime
 import os
+import sys
 
 from pyspark.sql import SparkSession
 from PysparkBenchReport import PysparkBenchReport
@@ -41,6 +42,14 @@ from PysparkBenchReport import PysparkBenchReport
 from check import check_json_summary_folder, get_abs_path
 from nds_schema import get_maintenance_schemas
 from nds_power import register_delta_tables
+
+# Python doesn't automatically include sibling directories in the import path.
+# We need to explicitly add the utils directory to sys.path to import shared utilities.
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+utils_dir = os.path.join(parent_dir, 'utils')
+if utils_dir not in sys.path:
+    sys.path.insert(0, utils_dir)
+from spark_utils import setQueryName, clearQueryName
 
 INSERT_FUNCS = [
     'LF_CR',
@@ -224,7 +233,7 @@ def run_query(spark_session,
         execution_time_list = register_delta_tables(spark_session, warehouse_path, execution_time_list)
     for query_name, q_content in query_dict.items():
         # show query name in Spark web UI
-        spark_session.sparkContext.setJobGroup(query_name, query_name)
+        setQueryName(spark_session, query_name)
         print(f"====== Run {query_name} ======")
         q_report = PysparkBenchReport(spark_session, query_name)
         summary = q_report.report_on(run_dm_query, 0, 1,
@@ -242,6 +251,7 @@ def run_query(spark_session,
             else:
                 summary_prefix =  os.path.join(json_summary_folder, '')
             q_report.write_summary(prefix=summary_prefix)
+    clearQueryName(spark_session)
     if not keep_sc:
         spark_session.sparkContext.stop()
     DM_end = datetime.now()

--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -46,6 +46,14 @@ from pyspark.sql import DataFrame
 from check import check_json_summary_folder, check_query_subset_exists, check_version
 from nds_schema import get_schemas
 
+# Python doesn't automatically include sibling directories in the import path.
+# We need to explicitly add the utils directory to sys.path to import shared utilities.
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+utils_dir = os.path.join(parent_dir, 'utils')
+if utils_dir not in sys.path:
+    sys.path.insert(0, utils_dir)
+from spark_utils import setQueryName, clearQueryName
+
 check_version()
 
 
@@ -475,9 +483,7 @@ def run_query_stream(input_prefix,
     
     for query_name, q_content in query_dict.items():
         # show query name in Spark web UI
-        spark_session.conf.set("spark.job.description", query_name)
-        spark_session.conf.set("spark.jobGroup.id", query_name)
-        spark_session.conf.set("spark.job.interruptOnCancel", "false")
+        setQueryName(spark_session, query_name)
         print("====== Run {} ======".format(query_name))
         q_report = PysparkBenchReport(spark_session, query_name)
         
@@ -519,9 +525,7 @@ def run_query_stream(input_prefix,
             else:
                 summary_prefix =  os.path.join(json_summary_folder, '')
             q_report.write_summary(prefix=summary_prefix)
-    spark_session.conf.unset("spark.job.description")
-    spark_session.conf.unset("spark.jobGroup.id")
-    spark_session.conf.unset("spark.job.interruptOnCancel")
+    clearQueryName(spark_session)
     power_end = int(time.time())
     power_elapse = int((power_end - power_start)*1000)
     

--- a/utils/spark_utils.py
+++ b/utils/spark_utils.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+#
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# -----
+#
+# Certain portions of the contents of this file are derived from TPC-DS version 3.2.0
+# (retrieved from www.tpc.org/tpc_documents_current_versions/current_specifications5.asp).
+# Such portions are subject to copyrights held by Transaction Processing Performance Council (“TPC”)
+# and licensed under the TPC EULA (a copy of which accompanies this file as “TPC EULA” and is also
+# available at http://www.tpc.org/tpc_documents_current_versions/current_specifications5.asp) (the “TPC EULA”).
+#
+# You may not use this file except in compliance with the TPC EULA.
+# DISCLAIMER: Portions of this file is derived from the TPC-DS Benchmark and as such any results
+# obtained using this file are not comparable to published TPC-DS Benchmark results, as the results
+# obtained from using this file do not comply with the TPC-DS Benchmark.
+#
+
+"""
+Utility functions for Spark benchmarks.
+"""
+
+
+def setQueryName(spark_session, query_name):
+    """Set the query name for display in Spark UI SQL tab.
+    
+    Uses duck typing to safely call sparkContext.setJobGroup when available
+    (standard Spark), and falls back to conf-based approach when not available
+    (e.g., Spark Connect).
+    
+    Args:
+        spark_session: The SparkSession instance
+        query_name: The name to display for this query in the Spark UI
+    """
+    try:
+        # Try using sparkContext.setJobGroup - this is the preferred method
+        # as it properly shows query names in the Spark UI SQL tab.
+        # This may fail in Spark Connect where sparkContext is not available.
+        sc = getattr(spark_session, 'sparkContext', None)
+        if sc is not None and hasattr(sc, 'setJobGroup'):
+            sc.setJobGroup(query_name, query_name)
+            return
+    except Exception:
+        pass
+    
+    # Fallback to conf-based approach for Spark Connect compatibility
+    # Note: This approach does not show query names in the SQL tab
+    # The 3 configs here are what setJobGroup sets automatically
+    # (interruptOnCancel=false is part of that).
+    try:
+        spark_session.conf.set("spark.job.description", query_name)
+        spark_session.conf.set("spark.jobGroup.id", query_name)
+        spark_session.conf.set("spark.job.interruptOnCancel", "false")
+    except Exception:
+        # If even this fails, just continue silently
+        pass
+
+
+def clearQueryName(spark_session):
+    """Clear the query name settings after query execution.
+    
+    Uses duck typing to safely clear job group when sparkContext is available,
+    and clears conf settings as fallback.
+    
+    Args:
+        spark_session: The SparkSession instance
+    """
+    try:
+        # Try clearing via sparkContext if available
+        sc = getattr(spark_session, 'sparkContext', None)
+        if sc is not None and hasattr(sc, 'setJobGroup'):
+            # Clear by setting empty values
+            sc.setJobGroup("", "")
+            return
+    except Exception:
+        pass
+    
+    # Fallback: clear conf-based settings
+    try:
+        spark_session.conf.unset("spark.job.description")
+        spark_session.conf.unset("spark.jobGroup.id")
+        spark_session.conf.unset("spark.job.interruptOnCancel")
+    except Exception:
+        # If even this fails, just continue silently
+        pass


### PR DESCRIPTION
Fixes: https://github.com/NVIDIA/spark-rapids-benchmarks/issues/241

With the code that is in the dev branch, we see this in the SQL tab:

<img width="1627" height="288" alt="Screenshot 2026-01-23 at 10 31 27 AM" src="https://github.com/user-attachments/assets/ecd4bbce-56dc-4be0-9800-13183515f476" />

With the change in this PR, we get the query names back:

<img width="1410" height="299" alt="Screenshot 2026-01-23 at 10 31 19 AM" src="https://github.com/user-attachments/assets/c627cdd5-c801-45b6-8fdb-78506fbd7280" />

The PR adds a util with a couple of functions that encapsulate the query name parts, and fixes some comments around how we deal with the utils folder being a sibling folder to nds/nds-h.

FYI @wbo4958 