### PR TITLE
Support profiling hook in nds-h

### DIFF
--- a/nds-h/nds_h_power.py
+++ b/nds-h/nds_h_power.py
@@ -47,6 +47,7 @@ utils_dir = os.path.join(parent_dir, 'utils')
 if utils_dir not in sys.path:
     sys.path.insert(0, utils_dir)
 from spark_utils import setQueryName, clearQueryName
+from profiler import Profiler
 
 from python_benchmark_reporter.PysparkBenchReport import PysparkBenchReport
 from pyspark.sql import DataFrame
@@ -235,7 +236,8 @@ def run_query_stream(input_prefix,
                      output_format="parquet",
                      json_summary_folder=None,
                      save_plan_path=None,
-                     skip_execution=False):
+                     skip_execution=False,
+                     profiling_hook=None):
     """run SQL in Spark and record execution time log. The execution time log is saved as a CSV file
     for easy accessibility. TempView Creation time is also recorded.
 
@@ -279,13 +281,17 @@ def run_query_stream(input_prefix,
     if sub_queries:
         query_dict = get_query_subset(query_dict, sub_queries)
 
+    # Setup profiler
+    profiler = Profiler(profiling_hook=profiling_hook, output_root=json_summary_folder)
+
     power_start = int(time.time())
     for query_name, q_content in query_dict.items():
         # show query name in Spark web UI
         setQueryName(spark_session, query_name)
         print("====== Run {} ======".format(query_name))
         q_report = PysparkBenchReport(spark_session, query_name)
-        summary = q_report.report_on(run_one_query,
+        with profiler(query_name):
+            summary = q_report.report_on(run_one_query,
                                      warmup_iterations,
                                      iterations,
                                      spark_session,
@@ -422,6 +428,10 @@ if __name__ == "__main__":
                         help='Skip the execution of the queries. This can be used in conjunction with ' +
                         '--save_plan_path to only save the execution plans without running the queries.' +
                         'Note that "spark.sql.adaptive.enabled" should be set to false to get GPU physical plans.')
+    parser.add_argument('--profiling_hook',
+                        help='Executable that is called just before/after a query executes.' +
+                        'The executable is called like this ' +
+                        './hook {start|stop} output_root query_name.')
     args = parser.parse_args()
     query_dict = gen_sql_from_stream(args.query_stream_file)
     run_query_stream(args.input_prefix,
@@ -438,4 +448,5 @@ if __name__ == "__main__":
                      args.output_format,
                      args.json_summary_folder,
                      args.save_plan_path,
-                     args.skip_execution)
+                     args.skip_execution,
+                     args.profiling_hook)

--- a/nds-h/nds_h_power.py
+++ b/nds-h/nds_h_power.py
@@ -290,7 +290,7 @@ def run_query_stream(input_prefix,
         setQueryName(spark_session, query_name)
         print("====== Run {} ======".format(query_name))
         q_report = PysparkBenchReport(spark_session, query_name)
-        with profiler(query_name):
+        with profiler(query_name=query_name):
             summary = q_report.report_on(run_one_query,
                                      warmup_iterations,
                                      iterations,

--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -36,8 +36,6 @@ import os
 import re
 import sys
 import time
-import subprocess 
-import shlex
 from collections import OrderedDict
 from pyspark.sql import SparkSession
 from PysparkBenchReport import PysparkBenchReport
@@ -53,48 +51,9 @@ utils_dir = os.path.join(parent_dir, 'utils')
 if utils_dir not in sys.path:
     sys.path.insert(0, utils_dir)
 from spark_utils import setQueryName, clearQueryName
+from profiler import Profiler
 
 check_version()
-
-
-class Profiler:
-    def __init__(self, profiling_hook, output_root):
-        self.profiling_hook = profiling_hook
-        self.output_root = output_root
-        self.is_profiling_enabled = output_root is not None and profiling_hook is not None
-
-        self.query_name = None
-
-    def __call__(self, query_name):
-        self.query_name = query_name
-        return self
-
-    def __enter__(self,):
-        self.start_profiling()
-        return self
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        self.stop_profiling()
-        self.query_name = None
-
-    def execute_script(self, action):
-        script_path = self.profiling_hook
-        command = f"{script_path} {action} {shlex.quote(self.output_root)} {shlex.quote(self.query_name)}"
-        try:
-            subprocess.run(command, shell=True, check=True)
-        except subprocess.CalledProcessError as e:
-            print(f"Error: Script exited with status {e.returncode}")
-            raise
-
-    def start_profiling(self):
-        if self.is_profiling_enabled:
-            print(f"Profiling started with profiling script: {self.profiling_hook} writing to {self.output_root} for query {self.query_name}.")
-            self.execute_script('start')
-
-    def stop_profiling(self):
-        if self.is_profiling_enabled:
-            self.execute_script('stop')
-            print("Profiling stopped")
 
 
 def split_and_strip(str, delimiter):

--- a/utils/profiler.py
+++ b/utils/profiler.py
@@ -30,7 +30,6 @@
 # obtained from using this file do not comply with the TPC-DS Benchmark.
 #
 
-import shlex
 import subprocess
 
 
@@ -61,9 +60,9 @@ class Profiler:
 
     def execute_script(self, action):
         script_path = self.profiling_hook
-        command = f"{script_path} {action} {shlex.quote(self.output_root)} {shlex.quote(self.query_name)}"
+        command = [script_path, action, self.output_root, self.query_name]
         try:
-            subprocess.run(command, shell=True, check=True)
+            subprocess.run(command, shell=False, check=True)
         except subprocess.CalledProcessError as e:
             print(f"Error: Script exited with status {e.returncode}")
             raise

--- a/utils/profiler.py
+++ b/utils/profiler.py
@@ -30,6 +30,7 @@
 # obtained from using this file do not comply with the TPC-DS Benchmark.
 #
 
+import os
 import subprocess
 
 
@@ -60,6 +61,13 @@ class Profiler:
 
     def execute_script(self, action):
         script_path = self.profiling_hook
+        if self.query_name is None:
+            raise ValueError("query_name must be set before executing profiling script. "
+                           "Use profiler(query_name='...') before entering context.")
+        if not os.path.isfile(script_path):
+            raise FileNotFoundError(f"Profiling hook script not found: {script_path}")
+        if not os.access(script_path, os.X_OK):
+            raise PermissionError(f"Profiling hook script is not executable: {script_path}")
         command = [script_path, action, self.output_root, self.query_name]
         try:
             result = subprocess.run(command, shell=False, check=True, capture_output=True, text=True)

--- a/utils/profiler.py
+++ b/utils/profiler.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# -----
+#
+# Certain portions of the contents of this file are derived from TPC-DS version 3.2.0
+# (retrieved from www.tpc.org/tpc_documents_current_versions/current_specifications5.asp).
+# Such portions are subject to copyrights held by Transaction Processing Performance Council (“TPC”)
+# and licensed under the TPC EULA (a copy of which accompanies this file as “TPC EULA” and is also
+# available at http://www.tpc.org/tpc_documents_current_versions/current_specifications5.asp) (the “TPC EULA”).
+#
+# You may not use this file except in compliance with the TPC EULA.
+# DISCLAIMER: Portions of this file is derived from the TPC-DS Benchmark and as such any results
+# obtained using this file are not comparable to published TPC-DS Benchmark results, as the results
+# obtained from using this file do not comply with the TPC-DS Benchmark.
+#
+
+import shlex
+import subprocess
+
+
+class Profiler:
+    """Context manager for executing profiling hooks before/after query execution.
+    
+    The profiling hook is an executable script that is called with:
+        ./hook {start|stop} output_root query_name
+    """
+    
+    def __init__(self, profiling_hook, output_root):
+        self.profiling_hook = profiling_hook
+        self.output_root = output_root
+        self.is_profiling_enabled = output_root is not None and profiling_hook is not None
+        self.query_name = None
+
+    def __call__(self, query_name):
+        self.query_name = query_name
+        return self
+
+    def __enter__(self):
+        self.start_profiling()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.stop_profiling()
+        self.query_name = None
+
+    def execute_script(self, action):
+        script_path = self.profiling_hook
+        command = f"{script_path} {action} {shlex.quote(self.output_root)} {shlex.quote(self.query_name)}"
+        try:
+            subprocess.run(command, shell=True, check=True)
+        except subprocess.CalledProcessError as e:
+            print(f"Error: Script exited with status {e.returncode}")
+            raise
+
+    def start_profiling(self):
+        if self.is_profiling_enabled:
+            print(f"Profiling started with profiling script: {self.profiling_hook} "
+                  f"writing to {self.output_root} for query {self.query_name}.")
+            self.execute_script('start')
+
+    def stop_profiling(self):
+        if self.is_profiling_enabled:
+            self.execute_script('stop')
+            print("Profiling stopped")

--- a/utils/profiler.py
+++ b/utils/profiler.py
@@ -62,9 +62,17 @@ class Profiler:
         script_path = self.profiling_hook
         command = [script_path, action, self.output_root, self.query_name]
         try:
-            subprocess.run(command, shell=False, check=True)
+            result = subprocess.run(command, shell=False, check=True, capture_output=True, text=True)
+            if result.stdout:
+                print(result.stdout)
+            if result.stderr:
+                print(result.stderr)
         except subprocess.CalledProcessError as e:
             print(f"Error: Script exited with status {e.returncode}")
+            if e.stdout:
+                print(f"stdout: {e.stdout}")
+            if e.stderr:
+                print(f"stderr: {e.stderr}")
             raise
 
     def start_profiling(self):


### PR DESCRIPTION
This adds support for the `--profiling_hook` argument in both nds-h and nds. It is useful so we can run something like nsys on a per query basis, during a power run.