### PR TITLE
Fall back to sys.argv[0] when __file__ is not defined

### DIFF
--- a/nds-h/nds_h_gen_data.py
+++ b/nds-h/nds_h_gen_data.py
@@ -37,7 +37,7 @@ import subprocess
 import shutil
 
 #For adding utils to path
-parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__ if '__file__' in dir() else sys.argv[0]), '..'))
 utils_dir = os.path.join(parent_dir, 'utils')
 sys.path.insert(0, utils_dir)
 

--- a/nds-h/nds_h_gen_query_stream.py
+++ b/nds-h/nds_h_gen_query_stream.py
@@ -34,7 +34,7 @@ import os
 import subprocess
 import sys
 
-parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__ if '__file__' in dir() else sys.argv[0]), '..'))
 utils_dir = os.path.join(parent_dir, 'utils')
 sys.path.insert(0, utils_dir)
 

--- a/nds-h/nds_h_power.py
+++ b/nds-h/nds_h_power.py
@@ -42,7 +42,7 @@ import subprocess
 
 # Python doesn't automatically include sibling directories in the import path.
 # We need to explicitly add the utils directory to sys.path to import shared utilities.
-parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__ if '__file__' in dir() else sys.argv[0]), '..'))
 utils_dir = os.path.join(parent_dir, 'utils')
 if utils_dir not in sys.path:
     sys.path.insert(0, utils_dir)

--- a/nds/nds_maintenance.py
+++ b/nds/nds_maintenance.py
@@ -45,7 +45,7 @@ from nds_power import register_delta_tables
 
 # Python doesn't automatically include sibling directories in the import path.
 # We need to explicitly add the utils directory to sys.path to import shared utilities.
-parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__ if '__file__' in dir() else sys.argv[0]), '..'))
 utils_dir = os.path.join(parent_dir, 'utils')
 if utils_dir not in sys.path:
     sys.path.insert(0, utils_dir)

--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -46,7 +46,7 @@ from nds_schema import get_schemas
 
 # Python doesn't automatically include sibling directories in the import path.
 # We need to explicitly add the utils directory to sys.path to import shared utilities.
-parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__ if '__file__' in dir() else sys.argv[0]), '..'))
 utils_dir = os.path.join(parent_dir, 'utils')
 if utils_dir not in sys.path:
     sys.path.insert(0, utils_dir)


### PR DESCRIPTION
Databricks runs Git-sourced Python files via IPython where __file__ is not defined, causing NameError. Use sys.argv[0] as fallback.