### PR TITLE
Improve Spark Connect compatibility for NDS and NDS-H

### DIFF
--- a/nds-h/README.md
+++ b/nds-h/README.md
@@ -264,6 +264,30 @@ parquet_sf3k \
 time.csv
 ```
 
+#### Power Run over Spark Connect
+
+`nds_h_power.py` also supports direct execution over Spark Connect. As with NDS power runs, do not
+use `spark-submit-template` for this path; run the script directly and pass `--spark_connect`.
+
+Example:
+
+```bash
+python nds_h_power.py \
+    parquet_sf3k \
+    ./nds_query_streams/query_0.sql \
+    time.csv \
+    --spark_connect sc://localhost
+```
+
+Expected smoke-test warnings are the same as for NDS:
+
+- Listener registration may be skipped when the RAPIDS Python listener is unavailable from the
+  client runtime.
+- Spark Connect may reject non-updatable Spark configs from client-side property files or defaults.
+  One example seen in smoke testing is `spark.locality.wait`.
+
+These warnings do not by themselves indicate a benchmark failure.
+
 ## Data Validation
 To validate query output between Power Runs with and without GPU, we provide [nds_h_validate.py](nds_h_validate.py) to do the job.
 

--- a/nds-h/nds_h_power.py
+++ b/nds-h/nds_h_power.py
@@ -58,6 +58,17 @@ from nds_h_schema import get_schemas
 check_version()
 
 
+def _get_app_id(spark_session):
+    # Spark Connect may not expose applicationId through sparkContext.
+    try:
+        return spark_session.conf.get("spark.app.id")
+    except Exception:
+        try:
+            return spark_session.sparkContext.applicationId
+        except Exception:
+            return "spark-connect"
+
+
 def gen_sql_from_stream(query_stream_file_path):
     """Read Spark compatible query stream and split them one by one
 
@@ -100,7 +111,7 @@ def setup_tables(spark_session, input_prefix, input_format, execution_time_list)
     Returns:
         execution_time_list: a list recording que15ry execution time.
     """
-    spark_app_id = spark_session.sparkContext.applicationId
+    spark_app_id = _get_app_id(spark_session)
     # Create TempView for tables
     for table_name in get_schemas().keys():
         start = int(time.time() * 1000)
@@ -120,7 +131,7 @@ def setup_tables(spark_session, input_prefix, input_format, execution_time_list)
 
 
 def register_delta_tables(spark_session, input_prefix, execution_time_list):
-    spark_app_id = spark_session.sparkContext.applicationId
+    spark_app_id = _get_app_id(spark_session)
     # Register tables for Delta Lake
     for table_name in get_schemas().keys():
         start = int(time.time() * 1000)
@@ -237,7 +248,8 @@ def run_query_stream(input_prefix,
                      save_plan_path=None,
                      skip_execution=False,
                      profiling_hook=None,
-                     app_name=None):
+                     app_name=None,
+                     spark_connect=None):
     """run SQL in Spark and record execution time log. The execution time log is saved as a CSV file
     for easy accessibility. TempView Creation time is also recorded.
 
@@ -264,13 +276,15 @@ def run_query_stream(input_prefix,
     # Execute Power Run or Specific query in Spark
     # build Spark Session
     session_builder = SparkSession.builder
+    if spark_connect:
+        session_builder = session_builder.remote(spark_connect)
     if property_file:
         spark_properties = load_properties(property_file)
         for k, v in spark_properties.items():
             session_builder = session_builder.config(k, v)
     spark_session = session_builder.appName(
         app_name).getOrCreate()
-    spark_app_id = spark_session.sparkContext.applicationId
+    spark_app_id = _get_app_id(spark_session)
     if input_format != 'iceberg' and input_format != 'delta':
         execution_time_list = setup_tables(spark_session, input_prefix, input_format,
                                            execution_time_list)
@@ -319,7 +333,7 @@ def run_query_stream(input_prefix,
     power_end = int(time.time())
     power_elapse = int((power_end - power_start)*1000)
     if not keep_sc:
-        spark_session.sparkContext.stop()
+        spark_session.stop()
     total_time_end = time.time()
     total_elapse = int((total_time_end - total_time_start) * 1000)
     print("====== Power Test Time: {} milliseconds ======".format(power_elapse))
@@ -424,6 +438,8 @@ if __name__ == "__main__":
                         help='Comma separated list of plan types to save. ' +
                         'e.g. "physical, logical". Default is "logical".',
                         default='logical')
+    parser.add_argument('--spark_connect',
+                        help='Spark Connect URI, e.g. sc://localhost:15002/;use_ssl=true;token=spark-secret-token')
     parser.add_argument('--skip_execution',
                         action='store_true',
                         help='Skip the execution of the queries. This can be used in conjunction with ' +
@@ -454,4 +470,5 @@ if __name__ == "__main__":
                      args.save_plan_path,
                      args.skip_execution,
                      args.profiling_hook,
-                     args.app_name)
+                     args.app_name,
+                     args.spark_connect)

--- a/nds/PysparkBenchReport.py
+++ b/nds/PysparkBenchReport.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -74,7 +74,7 @@ class PysparkBenchReport:
             import python_listener
             listener = python_listener.PythonListener()
             listener.register()
-        except TypeError as e:
+        except Exception as e:
             print("Not found com.nvidia.spark.rapids.listener.Manager", str(e))
             listener = None
         return listener
@@ -83,9 +83,14 @@ class PysparkBenchReport:
         if self._is_spark_400_or_later():
             from pyspark.sql import is_remote
             if is_remote():
-                return self.spark_session.conf.getAll
+                get_all = getattr(self.spark_session.conf, 'getAll', None)
+                return get_all() if callable(get_all) else (get_all or [])
 
-        return self.spark_session.sparkContext._conf.getAll()
+        try:
+            return self.spark_session.sparkContext._conf.getAll()
+        except Exception:
+            get_all = getattr(self.spark_session.conf, 'getAll', None)
+            return get_all() if callable(get_all) else (get_all or [])
 
 
     def report_on(self, fn: Callable, warmup_iterations = 0, iterations = 1, *args):

--- a/nds/README.md
+++ b/nds/README.md
@@ -443,6 +443,19 @@ run_query_stream(input_prefix=nds_data_path,
 `Note:` the python listener is disabled when running nds_power.py over Spark Connect, as py4j
 is not available in the Spark Connect environment.
 
+#### Expected Spark Connect warnings
+
+When running over Spark Connect, some warnings are expected during smoke testing:
+
+- Listener registration may be skipped when the RAPIDS Python listener is unavailable from the
+  client runtime. This is expected in Spark Connect environments where the classic Py4J listener
+  path is not available.
+- Spark Connect may reject non-updatable Spark configs from client-side property files or defaults.
+  One example seen in smoke testing is `spark.locality.wait`.
+
+These warnings do not by themselves indicate a benchmark failure. Review the final query status and
+time log output to determine whether the run completed successfully.
+
 ### Throughput Run
 
 Throughput Run simulates the scenario that multiple query sessions are running simultaneously in

--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -56,6 +56,17 @@ from profiler import Profiler
 check_version()
 
 
+def _get_app_id(spark_session):
+    # Spark Connect may not expose applicationId through sparkContext.
+    try:
+        return spark_session.conf.get("spark.app.id")
+    except Exception:
+        try:
+            return spark_session.sparkContext.applicationId
+        except Exception:
+            return "spark-connect"
+
+
 def split_and_strip(str, delimiter):
     return [s.strip() for s in str.split(delimiter) if s.strip()]
 
@@ -220,7 +231,7 @@ def setup_tables(spark_session, input_prefix, input_format, use_decimal, executi
     Returns:
         execution_time_list: a list recording query execution time.
     """
-    spark_app_id = spark_session.conf.get("spark.app.id")
+    spark_app_id = _get_app_id(spark_session)
     # Create TempView for tables
     for table_name in get_schemas(False).keys():
         start = int(time.time() * 1000)
@@ -237,7 +248,7 @@ def setup_tables(spark_session, input_prefix, input_format, use_decimal, executi
     return execution_time_list
 
 def register_delta_tables(spark_session, input_prefix, execution_time_list):
-    spark_app_id = spark_session.sparkContext.applicationId
+    spark_app_id = _get_app_id(spark_session)
     # Register tables for Delta Lake
     for table_name in get_schemas(False).keys():
         start = int(time.time() * 1000)
@@ -375,7 +386,8 @@ def run_query_stream(input_prefix,
                      profiling_hook=None,
                      save_plan_path=None,
                      skip_execution=False,
-                     app_name=None):
+                     app_name=None,
+                     spark_connect=None):
     """run SQL in Spark and record execution time log. The execution time log is saved as a CSV file
     for easy accesibility. TempView Creation time is also recorded.
 
@@ -404,6 +416,8 @@ def run_query_stream(input_prefix,
     # Execute Power Run or Specific query in Spark
     # build Spark Session
     session_builder = SparkSession.builder
+    if spark_connect:
+        session_builder = session_builder.remote(spark_connect)
     if property_file:
         spark_properties = load_properties(property_file)
         for k,v in spark_properties.items():
@@ -424,7 +438,7 @@ def run_query_stream(input_prefix,
     if input_format == 'delta' and delta_unmanaged:
         # Register tables for Delta Lake. This is only needed for unmanaged tables.
         execution_time_list = register_delta_tables(spark_session, input_prefix, execution_time_list)
-    spark_app_id = spark_session.conf.get("spark.app.id")
+    spark_app_id = _get_app_id(spark_session)
     if input_format != 'iceberg' and input_format != 'delta' and not hive_external:
         execution_time_list = setup_tables(spark_session, input_prefix, input_format, use_decimal,
                                            execution_time_list)
@@ -635,6 +649,8 @@ if __name__ == "__main__":
                         help='Comma separated list of plan types to save. ' +
                         'e.g. "physical, logical". Default is "logical".',
                         default='logical')
+    parser.add_argument('--spark_connect',
+                        help='Spark Connect URI, e.g. sc://localhost:15002/;use_ssl=true;token=spark-secret-token')
     parser.add_argument('--skip_execution',
                         action='store_true',
                         help='Skip the execution of the queries. This can be used in conjunction with ' +
@@ -681,4 +697,5 @@ if __name__ == "__main__":
                      args.profiling_hook,
                      args.save_plan_path,
                      args.skip_execution,
-                     args.app_name)
+                     args.app_name,
+                     args.spark_connect)

--- a/utils/python_benchmark_reporter/PysparkBenchReport.py
+++ b/utils/python_benchmark_reporter/PysparkBenchReport.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -56,6 +56,13 @@ class PysparkBenchReport:
             'query': query_name,
         }
 
+    def _get_spark_conf(self):
+        try:
+            return self.spark_session.sparkContext._conf.getAll()
+        except Exception:
+            get_all = getattr(self.spark_session.conf, 'getAll', None)
+            return get_all() if callable(get_all) else (get_all or [])
+
     def report_on(self, fn: Callable, warmup_iterations = 0, iterations = 1, *args):
         """Record a function for its running environment, running status etc. and exclude sentive
         information like tokens, secret and password Generate summary in dict format for it.
@@ -67,7 +74,7 @@ class PysparkBenchReport:
         Returns:
             dict: summary of the fn
         """
-        spark_conf = dict(self.spark_session.sparkContext._conf.getAll())
+        spark_conf = dict(self._get_spark_conf())
         env_vars = dict(os.environ)
         redacted = ["TOKEN", "SECRET", "PASSWORD"]
         filtered_env_vars = dict((k, env_vars[k]) for k in env_vars.keys() if not (k in redacted))
@@ -78,7 +85,7 @@ class PysparkBenchReport:
         try:
             listener = PythonListener()
             listener.register()
-        except TypeError as e:
+        except Exception as e:
             print("Not found com.nvidia.spark.rapids.listener.Manager", str(e))
             listener = None
         if listener is not None:


### PR DESCRIPTION
## Summary

  This PR tightens generic Spark Connect compatibility for the benchmark runners without adding router-specific behavior.

  It makes the runner and reporting paths more tolerant of Spark Connect environments where `sparkContext` access, listener
  registration, or config exposure differ from classic PySpark. It also documents the expected warning patterns seen during
  smoke testing so healthy Spark Connect runs do not look broken.

  ## Changes

  - add `--spark_connect` support to `nds_power.py` and `nds_h_power.py`
  - build remote sessions with `SparkSession.builder.remote(...)` when requested
  - stop assuming `applicationId` is always available through `sparkContext`
  - use `spark_session.stop()` for session shutdown in the Spark Connect path
  - harden both benchmark report implementations to fall back when `sparkContext` or listener registration is unavailable
  - document direct Spark Connect execution and expected smoke-test warnings in the NDS and NDS-H READMEs

  ## Why

  The previous benchmark code still had a few direct dependencies on classic Spark APIs that are not reliable in Spark Connect
  runs, especially around app id lookup, listener registration, and config access.

  The goal here is to keep the benchmark-side work generic:

  - no smart-router-specific flags or naming
  - no Aether-specific operational assumptions
  - preserve classic behavior when Spark Connect is not used

  ## Validation

  - `python3 -m py_compile nds/nds_power.py nds-h/nds_h_power.py nds/PysparkBenchReport.py utils/python_benchmark_reporter/
  PysparkBenchReport.py`
  - smoke-tested in the broader AB + Spark Connect + Spark2A flow after cleanup work, with the benchmark-side Spark Connect
  compatibility fallbacks working for that path

  ## Notes

  Expected Spark Connect smoke-test warnings are now documented explicitly, including:

  - missing RAPIDS Python listener registration from the client runtime
  - Spark Connect rejecting non-updatable configs such as `spark.locality.wait`