### PR TITLE
Fix __file__ NameError in power run scripts on Databricks

### DIFF
--- a/nds-h/nds_h_gen_data.py
+++ b/nds-h/nds_h_gen_data.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/nds-h/nds_h_gen_data.py
+++ b/nds-h/nds_h_gen_data.py
@@ -36,18 +36,8 @@ import sys
 import subprocess
 import shutil
 
-# Python doesn't automatically include sibling directories in the import path.
-# We need to explicitly add the utils directory to sys.path to import shared utilities.
-# Note: __file__ is not defined when Databricks runs scripts via exec(compile(...)),
-# so fall back to inspect to retrieve the filename from the compiled bytecode.
-try:
-    parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-except NameError:
-    import inspect
-    _this_file = inspect.getfile(inspect.currentframe())
-    parent_dir = os.path.abspath(os.path.join(os.path.dirname(_this_file), '..'))
-utils_dir = os.path.join(parent_dir, 'utils')
-sys.path.insert(0, utils_dir)
+from setup_utils import add_utils_to_sys_path
+add_utils_to_sys_path()
 
 from check import check_build_nds_h, check_version, get_abs_path, get_dir_size, parallel_value_type, valid_range
 

--- a/nds-h/nds_h_gen_data.py
+++ b/nds-h/nds_h_gen_data.py
@@ -36,8 +36,16 @@ import sys
 import subprocess
 import shutil
 
-#For adding utils to path
-parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+# Python doesn't automatically include sibling directories in the import path.
+# We need to explicitly add the utils directory to sys.path to import shared utilities.
+# Note: __file__ is not defined when Databricks runs scripts via exec(compile(...)),
+# so fall back to inspect to retrieve the filename from the compiled bytecode.
+try:
+    parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+except NameError:
+    import inspect
+    _this_file = inspect.getfile(inspect.currentframe())
+    parent_dir = os.path.abspath(os.path.join(os.path.dirname(_this_file), '..'))
 utils_dir = os.path.join(parent_dir, 'utils')
 sys.path.insert(0, utils_dir)
 

--- a/nds-h/nds_h_gen_query_stream.py
+++ b/nds-h/nds_h_gen_query_stream.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/nds-h/nds_h_gen_query_stream.py
+++ b/nds-h/nds_h_gen_query_stream.py
@@ -34,16 +34,8 @@ import os
 import subprocess
 import sys
 
-# Note: __file__ is not defined when Databricks runs scripts via exec(compile(...)),
-# so fall back to inspect to retrieve the filename from the compiled bytecode.
-try:
-    parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-except NameError:
-    import inspect
-    _this_file = inspect.getfile(inspect.currentframe())
-    parent_dir = os.path.abspath(os.path.join(os.path.dirname(_this_file), '..'))
-utils_dir = os.path.join(parent_dir, 'utils')
-sys.path.insert(0, utils_dir)
+from setup_utils import add_utils_to_sys_path
+add_utils_to_sys_path()
 
 from check import check_build_nds_h, check_version, get_abs_path
 

--- a/nds-h/nds_h_gen_query_stream.py
+++ b/nds-h/nds_h_gen_query_stream.py
@@ -34,7 +34,14 @@ import os
 import subprocess
 import sys
 
-parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+# Note: __file__ is not defined when Databricks runs scripts via exec(compile(...)),
+# so fall back to inspect to retrieve the filename from the compiled bytecode.
+try:
+    parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+except NameError:
+    import inspect
+    _this_file = inspect.getfile(inspect.currentframe())
+    parent_dir = os.path.abspath(os.path.join(os.path.dirname(_this_file), '..'))
 utils_dir = os.path.join(parent_dir, 'utils')
 sys.path.insert(0, utils_dir)
 

--- a/nds-h/nds_h_power.py
+++ b/nds-h/nds_h_power.py
@@ -42,11 +42,14 @@ import subprocess
 
 # Python doesn't automatically include sibling directories in the import path.
 # We need to explicitly add the utils directory to sys.path to import shared utilities.
-# Note: __file__ is not defined when Databricks runs scripts via exec(), so fall back to sys.argv[0].
+# Note: __file__ is not defined when Databricks runs scripts via exec(compile(...)),
+# so fall back to inspect to retrieve the filename from the compiled bytecode.
 try:
     parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 except NameError:
-    parent_dir = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), '..'))
+    import inspect
+    _this_file = inspect.getfile(inspect.currentframe())
+    parent_dir = os.path.abspath(os.path.join(os.path.dirname(_this_file), '..'))
 utils_dir = os.path.join(parent_dir, 'utils')
 if utils_dir not in sys.path:
     sys.path.insert(0, utils_dir)

--- a/nds-h/nds_h_power.py
+++ b/nds-h/nds_h_power.py
@@ -40,19 +40,8 @@ import sys
 import re
 import subprocess
 
-# Python doesn't automatically include sibling directories in the import path.
-# We need to explicitly add the utils directory to sys.path to import shared utilities.
-# Note: __file__ is not defined when Databricks runs scripts via exec(compile(...)),
-# so fall back to inspect to retrieve the filename from the compiled bytecode.
-try:
-    parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-except NameError:
-    import inspect
-    _this_file = inspect.getfile(inspect.currentframe())
-    parent_dir = os.path.abspath(os.path.join(os.path.dirname(_this_file), '..'))
-utils_dir = os.path.join(parent_dir, 'utils')
-if utils_dir not in sys.path:
-    sys.path.insert(0, utils_dir)
+from setup_utils import add_utils_to_sys_path
+add_utils_to_sys_path()
 from spark_utils import setQueryName, clearQueryName
 from profiler import Profiler
 

--- a/nds-h/nds_h_power.py
+++ b/nds-h/nds_h_power.py
@@ -42,7 +42,11 @@ import subprocess
 
 # Python doesn't automatically include sibling directories in the import path.
 # We need to explicitly add the utils directory to sys.path to import shared utilities.
-parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+# Note: __file__ is not defined when Databricks runs scripts via exec(), so fall back to sys.argv[0].
+try:
+    parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+except NameError:
+    parent_dir = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), '..'))
 utils_dir = os.path.join(parent_dir, 'utils')
 if utils_dir not in sys.path:
     sys.path.insert(0, utils_dir)

--- a/nds-h/setup_utils.py
+++ b/nds-h/setup_utils.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import inspect
+import os
+import sys
+
+
+def add_utils_to_sys_path():
+    """Add the sibling utils/ directory to sys.path so shared modules can be imported.
+
+    Uses inspect.stack() to resolve the calling script's location from the bytecode,
+    which works both in standard execution and in Databricks exec(compile(...)) contexts
+    where __file__ is not defined.
+    """
+    caller_file = inspect.stack()[1].filename
+    parent_dir = os.path.abspath(os.path.join(os.path.dirname(caller_file), '..'))
+    utils_dir = os.path.join(parent_dir, 'utils')
+    if utils_dir not in sys.path:
+        sys.path.insert(0, utils_dir)

--- a/nds/nds_maintenance.py
+++ b/nds/nds_maintenance.py
@@ -43,19 +43,8 @@ from check import check_json_summary_folder, get_abs_path
 from nds_schema import get_maintenance_schemas
 from nds_power import register_delta_tables
 
-# Python doesn't automatically include sibling directories in the import path.
-# We need to explicitly add the utils directory to sys.path to import shared utilities.
-# Note: __file__ is not defined when Databricks runs scripts via exec(compile(...)),
-# so fall back to inspect to retrieve the filename from the compiled bytecode.
-try:
-    parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-except NameError:
-    import inspect
-    _this_file = inspect.getfile(inspect.currentframe())
-    parent_dir = os.path.abspath(os.path.join(os.path.dirname(_this_file), '..'))
-utils_dir = os.path.join(parent_dir, 'utils')
-if utils_dir not in sys.path:
-    sys.path.insert(0, utils_dir)
+from setup_utils import add_utils_to_sys_path
+add_utils_to_sys_path()
 from spark_utils import setQueryName, clearQueryName
 
 INSERT_FUNCS = [

--- a/nds/nds_maintenance.py
+++ b/nds/nds_maintenance.py
@@ -45,7 +45,14 @@ from nds_power import register_delta_tables
 
 # Python doesn't automatically include sibling directories in the import path.
 # We need to explicitly add the utils directory to sys.path to import shared utilities.
-parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+# Note: __file__ is not defined when Databricks runs scripts via exec(compile(...)),
+# so fall back to inspect to retrieve the filename from the compiled bytecode.
+try:
+    parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+except NameError:
+    import inspect
+    _this_file = inspect.getfile(inspect.currentframe())
+    parent_dir = os.path.abspath(os.path.join(os.path.dirname(_this_file), '..'))
 utils_dir = os.path.join(parent_dir, 'utils')
 if utils_dir not in sys.path:
     sys.path.insert(0, utils_dir)

--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -44,19 +44,8 @@ from pyspark.sql import DataFrame
 from check import check_json_summary_folder, check_query_subset_exists, check_version
 from nds_schema import get_schemas
 
-# Python doesn't automatically include sibling directories in the import path.
-# We need to explicitly add the utils directory to sys.path to import shared utilities.
-# Note: __file__ is not defined when Databricks runs scripts via exec(compile(...)),
-# so fall back to inspect to retrieve the filename from the compiled bytecode.
-try:
-    parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-except NameError:
-    import inspect
-    _this_file = inspect.getfile(inspect.currentframe())
-    parent_dir = os.path.abspath(os.path.join(os.path.dirname(_this_file), '..'))
-utils_dir = os.path.join(parent_dir, 'utils')
-if utils_dir not in sys.path:
-    sys.path.insert(0, utils_dir)
+from setup_utils import add_utils_to_sys_path
+add_utils_to_sys_path()
 from spark_utils import setQueryName, clearQueryName
 from profiler import Profiler
 

--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -46,11 +46,14 @@ from nds_schema import get_schemas
 
 # Python doesn't automatically include sibling directories in the import path.
 # We need to explicitly add the utils directory to sys.path to import shared utilities.
-# Note: __file__ is not defined when Databricks runs scripts via exec(), so fall back to sys.argv[0].
+# Note: __file__ is not defined when Databricks runs scripts via exec(compile(...)),
+# so fall back to inspect to retrieve the filename from the compiled bytecode.
 try:
     parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 except NameError:
-    parent_dir = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), '..'))
+    import inspect
+    _this_file = inspect.getfile(inspect.currentframe())
+    parent_dir = os.path.abspath(os.path.join(os.path.dirname(_this_file), '..'))
 utils_dir = os.path.join(parent_dir, 'utils')
 if utils_dir not in sys.path:
     sys.path.insert(0, utils_dir)

--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -46,7 +46,11 @@ from nds_schema import get_schemas
 
 # Python doesn't automatically include sibling directories in the import path.
 # We need to explicitly add the utils directory to sys.path to import shared utilities.
-parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+# Note: __file__ is not defined when Databricks runs scripts via exec(), so fall back to sys.argv[0].
+try:
+    parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+except NameError:
+    parent_dir = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), '..'))
 utils_dir = os.path.join(parent_dir, 'utils')
 if utils_dir not in sys.path:
     sys.path.insert(0, utils_dir)

--- a/nds/setup_utils.py
+++ b/nds/setup_utils.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import inspect
+import os
+import sys
+
+
+def add_utils_to_sys_path():
+    """Add the sibling utils/ directory to sys.path so shared modules can be imported.
+
+    Uses inspect.stack() to resolve the calling script's location from the bytecode,
+    which works both in standard execution and in Databricks exec(compile(...)) contexts
+    where __file__ is not defined.
+    """
+    caller_file = inspect.stack()[1].filename
+    parent_dir = os.path.abspath(os.path.join(os.path.dirname(caller_file), '..'))
+    utils_dir = os.path.join(parent_dir, 'utils')
+    if utils_dir not in sys.path:
+        sys.path.insert(0, utils_dir)


### PR DESCRIPTION
This PR fixes a regression on DB platform after  this PR was merged - https://github.com/NVIDIA/spark-rapids-benchmarks/pull/243.


- Fixes NameError: name '__file__' is not defined that occurs when running nds_power.py or nds_h_power.py on Databricks, where scripts are executed via exec(compile(...)) rather than direct invocation.

- Uses inspect.stack() to resolve the calling script's location from the bytecode (co_filename), which correctly returns the script path that Databricks passes to compile().
- Extracted the path resolution logic into a reusable add_utils_to_sys_path() function in setup_utils.py to avoid duplicating the multi-line fix across files.
- Applied the fix to all five affected files

Fixes below error:


```
"NameError: name '__file__' is not defined\n[Trace ID: 00-0ec742bbbcdc1e38f6f7f0a9a405a7b9-28f79e43e09612e0-00]"
"\u001b[0;31m---------------------------------------------------------------------------\u001b[0m\n\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)\nFile \u001b[0;32m~/.ipykernel/2187/command--1-3962067571:8\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[38;5;28;01mdel\u001b[39;00m sys\n\u001b[1;32m      7\u001b[0m \u001b[38;5;28;01mwith\u001b[39;00m \u001b[38;5;28mopen\u001b[39m(filename, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mrb\u001b[39m\u001b[38;5;124m\"\u001b[39m) \u001b[38;5;28;01mas\u001b[39;00m f:\n\u001b[0;32m----> 8\u001b[0m   exec(\u001b[38;5;28mcompile\u001b[39m(f\u001b[38;5;241m.\u001b[39mread(), filename, \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mexec\u001b[39m\u001b[38;5;124m'\u001b[39m))\n\nFile \u001b[0;32m/Workspace/Repos/.internal/ff6841501e_commits/058f945478263612838602cdd586e7ffb23766e7/nds/nds_power.py:49\u001b[0m\n\u001b[1;32m     45\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mnds_schema\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m get_schemas\n\u001b[1;32m     47\u001b[0m \u001b[38;5;66;03m# Python doesn't automatically include sibling directories in the import path.\u001b[39;00m\n\u001b[1;32m     48\u001b[0m \u001b[38;5;66;03m# We need to explicitly add the utils directory to sys.path to import shared utilities.\u001b[39;00m\n\u001b[0;32m---> 49\u001b[0m parent_dir \u001b[38;5;241m=\u001b[39m os\u001b[38;5;241m.\u001b[39mpath\u001b[38;5;241m.\u001b[39mabspath(os\u001b[38;5;241m.\u001b[39mpath\u001b[38;5;241m.\u001b[39mjoin(os\u001b[38;5;241m.\u001b[39mpath\u001b[38;5;241m.\u001b[39mdirname(\u001b[38;5;18m__file__\u001b[39m), \u001b[38;5;124m'\u001b[39m\u001b[38;5;124m..\u001b[39m\u001b[38;5;124m'\u001b[39m))\n\u001b[1;32m     50\u001b[0m utils_dir \u001b[38;5;241m=\u001b[39m os\u001b[38;5;241m.\u001b[39mpath\u001b[38;5;241m.\u001b[39mjoin(parent_dir, \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mutils\u001b[39m\u001b[38;5;124m'\u001b[39m)\n\u001b[1;32m     51\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m utils_dir \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;129;01min\u001b[39;00m sys\u001b[38;5;241m.\u001b[39mpath:\n\n\u001b[0;31mNameError\u001b
```
```
[0m: name '__file__' is not defined"

```

