### PR TITLE
Update Code of Conduct contact email

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -42,7 +42,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at  [spark-rapids-conduct@nvidia.com](mailto:spark-rapids-conduct@nvidia.com)  All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at  [cudf-spark-conduct@nvidia.com](mailto:cudf-spark-conduct@nvidia.com)  All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project’s leadership.
 


### PR DESCRIPTION
## Summary
- replace the Spark RAPIDS conduct email with the cuDF Spark conduct distribution list
- update both the displayed address and `mailto` link

## Test plan
- [x] Verified the Code of Conduct references `cudf-spark-conduct@nvidia.com`