### PR TITLE
Update naming to NVIDIA cuDF plugin for Apache Spark

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Create a bug report to help us improve RAPIDS Accelerator for Apache Spark benchmark repository
+about: Create a bug report to help us improve the NVIDIA cuDF plugin for Apache Spark benchmark repository
 title: "[BUG]"
 labels: "? - Needs Triage, bug"
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Suggest an idea for RAPIDS Accelerator for Apache Spark benchmarks repository
+about: Suggest an idea for the NVIDIA cuDF plugin for Apache Spark benchmarks repository
 title: "[FEA]"
 labels: "? - Needs Triage, feature request"
 assignees: ''
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I wish the RAPIDS Accelerator for Apache Spark benchmark scripts would [...]
+A clear and concise description of what the problem is. Ex. I wish the NVIDIA cuDF plugin for Apache Spark benchmark scripts would [...]
 
 **Describe the solution you'd like**
 A clear and concise description of what you want to happen.

--- a/.github/ISSUE_TEMPLATE/submit-question.md
+++ b/.github/ISSUE_TEMPLATE/submit-question.md
@@ -1,6 +1,6 @@
 ---
 name: Submit question
-about: Ask a general question about RAPIDS Accelerator for Apache Spark benchmarks, or open a thread in the Discussions tab in the https://github.com/nvidia/spark-rapids repository
+about: Ask a general question about the NVIDIA cuDF plugin for Apache Spark benchmarks, or open a thread in the Discussions tab in the https://github.com/nvidia/cudf-spark repository
 title: "[QST]"
 labels: "? - Needs Triage, question"
 assignees: ''

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Define the code of conduct followed and enforced by the RAPIDS Accelerator for Apache Spark project
+Define the code of conduct followed and enforced by the NVIDIA cuDF plugin for Apache Spark project
 
 ### Intended audience
 
@@ -48,6 +48,6 @@ Project maintainers who do not follow or enforce the Code of Conduct in good fai
 
 ## Attribution
 
-This Code of Conduct was taken from the [NVIDIA RAPIDS](https://docs.rapids.ai/resources/conduct/) project, which was adapted from the  [Contributor Covenant](https://www.contributor-covenant.org/), version 1.4, available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+This Code of Conduct was taken from the [NVIDIA cuDF](https://docs.rapids.ai/resources/conduct/) project, which was adapted from the  [Contributor Covenant](https://www.contributor-covenant.org/), version 1.4, available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
 
 For answers to common questions about this code of conduct, see https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to Spark RAPIDS Benchmarks
+# Contributing to NVIDIA cuDF plugin for Apache Spark Benchmarks
 
-Contributing to Spark RAPIDS Benchmarks fall into the following three categories.
+Contributing to NVIDIA cuDF plugin for Apache Spark Benchmarks fall into the following three categories.
 
 1. To report a bug, request a new feature, or report a problem with
     documentation, please file an issue
@@ -179,4 +179,4 @@ export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"
 ```
 
 ## Attribution
-Portions adopted from https://github.com/NVIDIA/spark-rapids/blob/main/CONTRIBUTING.md
+Portions adopted from https://github.com/NVIDIA/cudf-spark/blob/main/CONTRIBUTING.md

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Spark RAPIDS Benchmarks
+# NVIDIA cuDF plugin for Apache Spark Benchmarks
 
 A repo for Spark related benchmark sets and utilities using the 
-[RAPIDS Accelerator For Apache Spark](https://github.com/NVIDIA/spark-rapids). 
+[NVIDIA cuDF plugin for Apache Spark](https://github.com/NVIDIA/cudf-spark). 
 
 ## Benchmark sets:
-- [Nvidia Decision Support ( NDS )](./nds/)
-- [Nvidia Decision Support-H ( NDS-H )](./nds-h/)
+- [NVIDIA Decision Support ( NDS )](./nds/)
+- [NVIDIA Decision Support-H ( NDS-H )](./nds-h/)
 
 Please see README in each benchmark set for more details including building instructions and usage
 descriptions.

--- a/env-detector/README.md
+++ b/env-detector/README.md
@@ -1,6 +1,7 @@
-# Spark Rapids Environment Detector
+# NVIDIA cuDF plugin for Apache Spark Environment Detector
 
-A tool for automatically detecting Spark cluster environment configuration, helping to optimize spark-rapids POC testing environments.
+A tool for automatically detecting Spark cluster environment configuration, helping to optimize
+NVIDIA cuDF plugin for Apache Spark POC testing environments.
 
 ## Features
 
@@ -49,7 +50,7 @@ This tool can automatically detect the following environment information:
   - CUDA version
   - cuDNN version
   - NCCL version
-  - spark-rapids plugin version
+  - cudf-spark plugin version
   - nvidia-peermem status
   - libcuda.so presence
   - GPUDirect Storage status
@@ -60,7 +61,7 @@ This tool can automatically detect the following environment information:
 - Shuffle partitions
 - Dynamic allocation status
 - Adaptive execution status
-- RAPIDS plugin status
+- cuDF plugin status
 - Important config items
 - spark-defaults.conf content
 
@@ -177,7 +178,7 @@ spark-submit \
 
 ```
 ================================================================================
-SPARK RAPIDS ENVIRONMENT REPORT
+CUDF PLUGIN ENVIRONMENT REPORT
 ================================================================================
 Generated: 2024-01-15 14:30:25
 

--- a/env-detector/README.md
+++ b/env-detector/README.md
@@ -50,7 +50,7 @@ This tool can automatically detect the following environment information:
   - CUDA version
   - cuDNN version
   - NCCL version
-  - spark-rapids plugin version
+  - cuDF plugin version
   - nvidia-peermem status
   - libcuda.so presence
   - GPUDirect Storage status
@@ -178,7 +178,7 @@ spark-submit \
 
 ```
 ================================================================================
-SPARK RAPIDS ENVIRONMENT REPORT
+CUDF PLUGIN ENVIRONMENT REPORT
 ================================================================================
 Generated: 2024-01-15 14:30:25
 

--- a/env-detector/README.md
+++ b/env-detector/README.md
@@ -50,7 +50,7 @@ This tool can automatically detect the following environment information:
   - CUDA version
   - cuDNN version
   - NCCL version
-  - cudf-spark plugin version
+  - spark-rapids plugin version
   - nvidia-peermem status
   - libcuda.so presence
   - GPUDirect Storage status
@@ -61,7 +61,7 @@ This tool can automatically detect the following environment information:
 - Shuffle partitions
 - Dynamic allocation status
 - Adaptive execution status
-- cuDF plugin status
+- RAPIDS status
 - Important config items
 - spark-defaults.conf content
 
@@ -178,7 +178,7 @@ spark-submit \
 
 ```
 ================================================================================
-CUDF PLUGIN ENVIRONMENT REPORT
+SPARK RAPIDS ENVIRONMENT REPORT
 ================================================================================
 Generated: 2024-01-15 14:30:25
 

--- a/env-detector/build.sh
+++ b/env-detector/build.sh
@@ -16,11 +16,11 @@
 # limitations under the License.
 #
 
-# Build script for Spark Rapids Environment Detector
+# Build script for the NVIDIA cuDF plugin for Apache Spark Environment Detector
 
 set -e
 
-echo "Building Spark Rapids Environment Detector..."
+echo "Building the NVIDIA cuDF plugin for Apache Spark Environment Detector..."
 echo
 
 # Check if Maven is installed

--- a/env-detector/pom.xml
+++ b/env-detector/pom.xml
@@ -26,8 +26,8 @@
     <version>1.0.0</version>
     <packaging>jar</packaging>
 
-    <name>Spark Rapids Environment Detector</name>
-    <description>A tool to detect and report Spark cluster environment configuration for spark-rapids POC</description>
+    <name>NVIDIA cuDF plugin for Apache Spark Environment Detector</name>
+    <description>A tool to detect and report Spark cluster environment configuration for a cuDF plugin POC</description>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/env-detector/run-cluster.sh
+++ b/env-detector/run-cluster.sh
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-# Run script for Spark Rapids Environment Detector on a cluster
+# Run script for the NVIDIA cuDF plugin for Apache Spark Environment Detector on a cluster
 
 set -e
 
@@ -93,7 +93,7 @@ DRIVER_MEMORY=${DRIVER_MEMORY:-4g}
 EXECUTOR_MEMORY=${EXECUTOR_MEMORY:-16g}
 EXECUTOR_CORES=${EXECUTOR_CORES:-16}
 
-echo "Running Spark Rapids Environment Detector on cluster..."
+echo "Running NVIDIA cuDF plugin for Apache Spark Environment Detector on cluster..."
 echo "Master: $MASTER_URL"
 echo "Driver Memory: $DRIVER_MEMORY"
 echo "Executor Memory: $EXECUTOR_MEMORY"

--- a/env-detector/run.sh
+++ b/env-detector/run.sh
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-# Run script for Spark Rapids Environment Detector (local mode)
+# Run script for the NVIDIA cuDF plugin for Apache Spark Environment Detector (local mode)
 
 set -e
 
@@ -43,7 +43,7 @@ fi
 # Output path (optional)
 OUTPUT_PATH="$1"
 
-echo "Running Spark Rapids Environment Detector..."
+echo "Running the NVIDIA cuDF plugin for Apache Spark Environment Detector..."
 echo "=============================================="
 echo
 

--- a/env-detector/src/main/scala/com/nvidia/sparkrapids/envdetector/EnvDetector.scala
+++ b/env-detector/src/main/scala/com/nvidia/sparkrapids/envdetector/EnvDetector.scala
@@ -25,9 +25,9 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.SparkContext
 
 /**
- * Main entry point for the Spark Rapids Environment Detector.
+ * Main entry point for the NVIDIA cuDF plugin for Apache Spark Environment Detector.
  * This tool automatically detects and reports cluster environment configuration
- * and runs performance benchmarks to help optimize spark-rapids POC testing.
+ * and runs performance benchmarks to help optimize cuDF plugin POC testing.
  * 
  * Usage:
  *   spark-submit --class com.nvidia.sparkrapids.envdetector.EnvDetector \
@@ -55,12 +55,12 @@ object EnvDetector {
     }
 
     val spark = SparkSession.builder()
-      .appName("Spark Rapids Environment Detector")
+      .appName("NVIDIA cuDF plugin for Apache Spark Environment Detector")
       .getOrCreate()
 
     try {
       println("=" * 80)
-      println("Spark Rapids Environment Detector")
+      println("NVIDIA cuDF plugin for Apache Spark Environment Detector")
       println("=" * 80)
       println()
 
@@ -110,11 +110,11 @@ object EnvDetector {
 
   private def printHelp(): Unit = {
     println("""
-Spark Rapids Environment Detector
+NVIDIA cuDF plugin for Apache Spark Environment Detector
 ==================================
 
 A tool to detect cluster environment configuration and run performance benchmarks
-to help diagnose spark-rapids POC testing issues.
+to help diagnose the cuDF plugin POC testing issues.
 
 Usage:
   spark-submit --class com.nvidia.sparkrapids.envdetector.EnvDetector \

--- a/nds-h/README.md
+++ b/nds-h/README.md
@@ -30,7 +30,7 @@ You may not use NDS-H except in compliance with the Apache License, Version 2.0 
     - Download latest distro from [here](https://spark.apache.org/downloads.html)
     - Preferably >= 3.4
     - Find and note SPARK_HOME ( /DOWNLOAD/LOCATION/spark-<3.4.1>-bin-hadoop3 )
-    - (For local) Follow the steps mentioned [here](https://docs.nvidia.com/spark-rapids/user-guide/latest/getting-started/on-premise.html#local-mode)
+    - (For local) Follow the steps mentioned [here](https://docs.nvidia.com/cudf-spark/latest/getting-started/on-premise.html#local-mode)
       for local setup
     - (For local) Update *_gpu_* --files with the getGpuResources.sh location as mentioned in the link above
     - (For local) Update spark master in shared/base.template with local[*]
@@ -40,9 +40,9 @@ You may not use NDS-H except in compliance with the Apache License, Version 2.0 
     - Update [shared/base.template](../shared/base.template) line 26 with the Spark home location.
 
 5. For GPU run
-    - Download the latest RAPIDS jar from [here](https://oss.sonatype.org/content/repositories/staging/com/nvidia/rapids-4-spark_2.12/)
+    - Download the latest NVIDIA cuDF plugin for Apache Spark jar from [here](https://oss.sonatype.org/content/repositories/staging/com/nvidia/rapids-4-spark_2.12/)
   
-    - Update [shared/base.template](../shared/base.template) line 36 with rapids plugin jar location
+    - Update [shared/base.template](../shared/base.template) line 36 with the cuDF plugin jar location
 
 6. TPC-H Tools
 
@@ -216,7 +216,9 @@ positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
   --input_format {parquet,orc,avro,csv,json,iceberg,delta}
-                        type for input data source, e.g. parquet, orc, json, csv or iceberg, delta. Certain types are not fully supported by GPU reading, please refer to https://github.com/NVIDIA/spark-rapids/blob/branch-24.08/docs/compatibility.md for more details.
+                        type for input data source, e.g. parquet, orc, json, csv or iceberg,
+  delta. Certain types are not fully supported by GPU reading, please refer to
+  https://github.com/NVIDIA/cudf-spark/blob/main/docs/compatibility.md for more details.
   --output_prefix OUTPUT_PREFIX
                         text to prepend to every output file (e.g., "hdfs:///ds-parquet")
   --output_format OUTPUT_FORMAT
@@ -281,7 +283,7 @@ python nds_h_power.py \
 
 Expected smoke-test warnings are the same as for NDS:
 
-- Listener registration may be skipped when the RAPIDS Python listener is unavailable from the
+- Listener registration may be skipped when the cuDF plugin Python listener is unavailable from the
   client runtime.
 - Spark Connect may reject non-updatable Spark configs from client-side property files or defaults.
   One example seen in smoke testing is `spark.locality.wait`.

--- a/nds-h/nds_h_power.py
+++ b/nds-h/nds_h_power.py
@@ -442,7 +442,7 @@ if __name__ == "__main__":
     parser.add_argument('--input_format',
                         help='type for input data source, e.g. parquet, orc, json, csv or iceberg, delta. ' +
                              'Certain types are not fully supported by GPU reading, please refer to ' +
-                             'https://github.com/NVIDIA/spark-rapids/blob/branch-24.08/docs/compatibility.md ' +
+                             'https://github.com/NVIDIA/cudf-spark/blob/main/docs/compatibility.md ' +
                              'for more details.',
                         choices=['parquet', 'orc', 'avro', 'csv', 'json', 'iceberg', 'delta'],
                         default='parquet')

--- a/nds-h/nds_h_validate.py
+++ b/nds-h/nds_h_validate.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/nds-h/nds_h_validate.py
+++ b/nds-h/nds_h_validate.py
@@ -50,7 +50,7 @@ SKIP_QUERIES = [
     'query15_part3', # drop view query
 ]
 SKIP_COLUMNS = {
-    'query18': ['o_orderkey'], # non-deterministic output: https://github.com/NVIDIA/spark-rapids-benchmarks/pull/198#issuecomment-2403837688
+    'query18': ['o_orderkey'], # non-deterministic output: https://github.com/NVIDIA/cudf-spark-benchmarks/pull/198#issuecomment-2403837688
 }
 
 

--- a/nds/README.md
+++ b/nds/README.md
@@ -90,7 +90,7 @@ Note that if your OS's default `gcc` version is 10+ the most recent version of
 TPC-DS Tools 3.2 does not link due to errors such as:
 
 ```text
-/usr/bin/ld: s_purchase.o:/home/gshegalov/gits/NVIDIA/spark-rapids-benchmarks/nds/tpcds-gen/target/tools/s_purchase.c:55: multiple definition of `nItemIndex'; s_catalog_order.o:/home/gshegalov/gits/NVIDIA/spark-rapids-benchmarks/nds/tpcds-gen/target/tools/s_catalog_order.c:56: first defined here
+/usr/bin/ld: s_purchase.o:/home/gshegalov/gits/NVIDIA/cudf-spark-benchmarks/nds/tpcds-gen/target/tools/s_purchase.c:55: multiple definition of `nItemIndex'; s_catalog_order.o:/home/gshegalov/gits/NVIDIA/cudf-spark-benchmarks/nds/tpcds-gen/target/tools/s_catalog_order.c:56: first defined here
 ```
 
 as a result of defaulting to [`-fno-common`](https://gcc.gnu.org/gcc-10/porting_to.html#common).
@@ -229,7 +229,7 @@ User can also use `spark-submit` to submit `nds_transcode.py` directly.
 We provide two basic templates for GPU run(convert_submit_gpu.template) and CPU run(convert_submit_cpu.template).
 To enable GPU run, user needs to download the following jar.
 
-[spark-rapids jar](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/22.10.0/rapids-4-spark_2.12-22.10.0.jar)
+[cuDF plugin jar](https://repo1.maven.org/maven2/com/nvidia/rapids-4-spark_2.12/22.10.0/rapids-4-spark_2.12-22.10.0.jar)
 
 After that, please set environment variable `SPARK_RAPIDS_PLUGIN_JAR` to the path where the jars are
 downloaded to in spark submit templates.
@@ -327,7 +327,9 @@ positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
   --input_format {parquet,orc,avro,csv,json,iceberg,delta}
-                        type for input data source, e.g. parquet, orc, json, csv or iceberg, delta. Certain types are not fully supported by GPU reading, please refer to https://github.com/NVIDIA/spark-rapids/blob/branch-22.08/docs/compatibility.md for more details.
+                        type for input data source, e.g. parquet, orc, json, csv or iceberg,
+  delta. Certain types are not fully supported by GPU reading, please refer to
+  https://github.com/NVIDIA/cudf-spark/blob/main/docs/compatibility.md for more details.
   --output_prefix OUTPUT_PREFIX
                         text to prepend to every output file (e.g., "hdfs:///ds-parquet")
   --output_format OUTPUT_FORMAT
@@ -447,7 +449,7 @@ is not available in the Spark Connect environment.
 
 When running over Spark Connect, some warnings are expected during smoke testing:
 
-- Listener registration may be skipped when the RAPIDS Python listener is unavailable from the
+- Listener registration may be skipped when the cuDF plugin Python listener is unavailable from the
   client runtime. This is expected in Spark Connect environments where the classic Py4J listener
   path is not available.
 - Spark Connect may reject non-updatable Spark configs from client-side property files or defaults.
@@ -496,7 +498,7 @@ DELETE queries while `LF_*.sql` are INSERT queries.
 Note: The Delete functions in Data Maintenance cannot run successfully in Spark 3.2.0 and 3.2.1 due
 to a known Spark [issue](https://issues.apache.org/jira/browse/SPARK-39454). User can run it in Spark 3.2.2
 or later. More details including work-around for version 3.2.0 and 3.2.1 could be found in this
-[link](https://github.com/NVIDIA/spark-rapids-benchmarks/pull/9#issuecomment-1141956487)
+[link](https://github.com/NVIDIA/cudf-spark-benchmarks/pull/9#issuecomment-1141956487)
 
 Arguments supported for data maintenance:
 
@@ -539,7 +541,7 @@ time.csv \
 Note: to make the maintenance query compatible in Spark, we made the following changes:
 
 1. change `CREATE VIEW` to `CREATE TEMP VIEW` in all INSERT queries due to [[SPARK-29630]](https://github.com/apache/spark/pull/26361)
-2. change data type for column `sret_ticket_number` in table `s_store_returns` from `char(20)` to `bigint` due to [known issue](https://github.com/NVIDIA/spark-rapids-benchmarks/pull/9#issuecomment-1138379596)
+2. change data type for column `sret_ticket_number` in table `s_store_returns` from `char(20)` to `bigint` due to [known issue](https://github.com/NVIDIA/cudf-spark-benchmarks/pull/9#issuecomment-1138379596)
 
 ## Data Validation
 

--- a/nds/README.md
+++ b/nds/README.md
@@ -327,8 +327,7 @@ positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
   --input_format {parquet,orc,avro,csv,json,iceberg,delta}
-                        type for input data source, e.g. parquet, orc, json, csv or iceberg,
-  delta. Certain types are not fully supported by GPU reading, please refer to
+                        type for input data source, e.g. parquet, orc, json, csv or iceberg, delta. Certain types are not fully supported by GPU reading, please refer to
   https://github.com/NVIDIA/cudf-spark/blob/main/docs/compatibility.md for more details.
   --output_prefix OUTPUT_PREFIX
                         text to prepend to every output file (e.g., "hdfs:///ds-parquet")

--- a/nds/base.template
+++ b/nds/base.template
@@ -32,6 +32,6 @@ export EXECUTOR_MEMORY=${EXECUTOR_MEMORY:-16G}
 
 # The NDS listener jar which is built in utils/jvm_listener directory.
 export NDS_LISTENER_JAR=${NDS_LISTENER_JAR:-../utils/jvm_listener/target/benchmark-listener-1.0-SNAPSHOT.jar}
-# The spark-rapids jar which is required when running on GPU
+# The cuDF plugin jar which is required when running on GPU
 export SPARK_RAPIDS_PLUGIN_JAR=${SPARK_RAPIDS_PLUGIN_JAR:-rapids-4-spark_2.12-22.06.0.jar}
 export PYTHONPATH=$SPARK_HOME/python:`echo $SPARK_HOME/python/lib/py4j-*.zip`

--- a/nds/nds_power.py
+++ b/nds/nds_power.py
@@ -635,7 +635,7 @@ if __name__ == "__main__":
     parser.add_argument('--input_format',
                         help='type for input data source, e.g. parquet, orc, json, csv or iceberg, delta. ' +
                         'Certain types are not fully supported by GPU reading, please refer to ' +
-                        'https://github.com/NVIDIA/spark-rapids/blob/branch-22.08/docs/compatibility.md ' +
+                        'https://github.com/NVIDIA/cudf-spark/blob/main/docs/compatibility.md ' +
                         'for more details.',
                         choices=['parquet', 'orc', 'avro', 'csv', 'json', 'iceberg', 'delta'],
                         default='parquet')

--- a/nds/nds_schema.py
+++ b/nds/nds_schema.py
@@ -325,7 +325,7 @@ def get_schemas(use_decimal):
         StructField("sr_addr_sk", identifier_int),
         StructField("sr_store_sk", identifier_int),
         StructField("sr_reason_sk", identifier_int),
-        # Use LongType due to https://github.com/NVIDIA/spark-rapids-benchmarks/pull/9#issuecomment-1138379596
+        # Use LongType due to https://github.com/NVIDIA/cudf-spark-benchmarks/pull/9#issuecomment-1138379596
         # Databricks is using LongType as well in their accepted benchmark reports.
         # See https://www.tpc.org/results/supporting_files/tpcds/databricks~tpcds~100000~databricks_SQL_8.3~sup-1~2021-11-02~v01.zip
         StructField("sr_ticket_number", identifier_long, nullable=False),

--- a/nds/nds_schema.py
+++ b/nds/nds_schema.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/nds/nds_validate.py
+++ b/nds/nds_validate.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/nds/nds_validate.py
+++ b/nds/nds_validate.py
@@ -145,7 +145,7 @@ def collect_results(df: DataFrame,
 
 def check_nth_col_problematic_q78(q78_content: str) -> int:
     """parse the query78 content, return which column is the problematic one.
-    example content: https://github.com/NVIDIA/spark-rapids-benchmarks/issues/101#issuecomment-1217758683
+    example content: https://github.com/NVIDIA/cudf-spark-benchmarks/issues/101#issuecomment-1217758683
     parse logic:
     1. find the content between the last "select" and "from" pair.
     2. split the content by ", " or ",\n"
@@ -167,11 +167,11 @@ def rowEqual(row1, row2, epsilon, is_q78, q78_problematic_col):
     # only simple types in a row for NDS results
     if is_q78:
         # TODO: make the special compare for q78 more common and make it apply to other queries that contain round function
-        # TODO: remove this special case after we resolve https://github.com/NVIDIA/spark-rapids/issues/1573
-        # see example error case: https://github.com/NVIDIA/spark-rapids-benchmarks/pull/7#issue-1247422850
+        # TODO: remove this special case after we resolve https://github.com/NVIDIA/cudf-spark/issues/1573
+        # see example error case: https://github.com/NVIDIA/cudf-spark-benchmarks/pull/7#issue-1247422850
         # Pop the 2nd or 4th column value in q78, compare it alone.
         # It is possible the problematic column are at different positions in different streams,
-        # see example and more details: https://github.com/NVIDIA/spark-rapids-benchmarks/issues/101#issuecomment-1217758683
+        # see example and more details: https://github.com/NVIDIA/cudf-spark-benchmarks/issues/101#issuecomment-1217758683
         if q78_problematic_col != 2 and q78_problematic_col != 4:
             raise Exception(f"q78 problematic column should be 2nd or 4th, but get {q78_problematic_col}")
         # remember to -1 to get the index in python list
@@ -228,10 +228,10 @@ def iterate_queries(spark_session: SparkSession,
     unmatch_queries = []
     for query_name in query_dict.keys():
         if query_name == 'query65':
-            # query65 is skipped due to: https://github.com/NVIDIA/spark-rapids-benchmarks/pull/7#issuecomment-1147077894
+            # query65 is skipped due to: https://github.com/NVIDIA/cudf-spark-benchmarks/pull/7#issuecomment-1147077894
             continue
         if query_name == 'query67' and is_float:
-            # query67 is skipped due to: https://github.com/NVIDIA/spark-rapids-benchmarks/pull/7#issuecomment-1156214630
+            # query67 is skipped due to: https://github.com/NVIDIA/cudf-spark-benchmarks/pull/7#issuecomment-1156214630
             continue
         sub_input1 = input1 + '/' + query_name
         sub_input2 = input2 + '/' + query_name

--- a/shared/base.template
+++ b/shared/base.template
@@ -32,6 +32,6 @@ export EXECUTOR_MEMORY=${EXECUTOR_MEMORY:-16G}
 
 # The NDS listener jar which is built in jvm_listener directory.
 export NDS_LISTENER_JAR=${NDS_LISTENER_JAR:-../utils/jvm_listener/target/benchmark-listener-1.0-SNAPSHOT.jar}
-# The spark-rapids jar which is required when running on GPU
+# The cuDF plugin jar which is required when running on GPU
 export SPARK_RAPIDS_PLUGIN_JAR=${SPARK_RAPIDS_PLUGIN_JAR:-rapids-4-spark_2.12-24.04.0-cuda11.jar}
 export PYTHONPATH=$SPARK_HOME/python:`echo $SPARK_HOME/python/lib/py4j-*.zip`

--- a/shared/base.template
+++ b/shared/base.template
@@ -1,5 +1,5 @@
 #
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Updating naming from RAPIDS Accelerator for Apache Spark to the NVIDIA cuDF plugin for Apache Spark.  Short name is the cuDF plugin. 

Also, changed some URL links.  